### PR TITLE
Remove global vars

### DIFF
--- a/fingerprint.c
+++ b/fingerprint.c
@@ -30,24 +30,31 @@
 #include "fpc_imp.h"
 
 
-uint64_t challenge = 0;
-bool auth_thread_running = false;
+typedef struct {
+    pthread_t thread;
+    bool thread_running;
+} fpc_thread_t;
 
-pthread_t thread;
-pthread_mutex_t lock;
+typedef struct {
+    fingerprint_device_t device;  // "inheritance"
+    fpc_thread_t worker;
+    fpc_imp_data_t *fpc;
+    uint32_t gid;
+    char db_path[255];
+    pthread_mutex_t lock;
+    uint64_t challenge;
+} sony_fingerprint_device_t;
 
-fingerprint_notify_t callback;
-static char db_path[255];
-static uint32_t fpc_gid = 0;
-
-void *enroll_thread_loop()
+void *enroll_thread_loop(void *arg)
 {
     ALOGI("%s", __func__);
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)arg;
+    fingerprint_notify_t callback = sdev->device.notify;
 
-    int32_t print_count = fpc_get_print_count();
+    int32_t print_count = fpc_get_print_count(sdev->fpc);
     ALOGD("%s : print count is : %u", __func__, print_count);
 
-    int ret = fpc_enroll_start(print_count);
+    int ret = fpc_enroll_start(sdev->fpc, print_count);
     if(ret < 0)
     {
         ALOGE("Starting enrol failed: %d\n", ret);
@@ -55,7 +62,7 @@ void *enroll_thread_loop()
 
     int status = 1;
 
-    while((status = fpc_capture_image()) >= 0) {
+    while((status = fpc_capture_image(sdev->fpc)) >= 0) {
         ALOGD("%s : Got Input status=%d", __func__, status);
 
         if (status <= FINGERPRINT_ACQUIRED_TOO_FAST) {
@@ -69,7 +76,7 @@ void *enroll_thread_loop()
         if (status == FINGERPRINT_ACQUIRED_GOOD) {
             ALOGI("%s : Enroll Step", __func__);
             uint32_t remaining_touches = 0;
-            int ret = fpc_enroll_step(&remaining_touches);
+            int ret = fpc_enroll_step(sdev->fpc, &remaining_touches);
             ALOGE("%s: step: %d, touches=%d\n", __func__, ret, remaining_touches);
             if (ret > 0) {
                 ALOGI("%s : Touches Remaining : %d", __func__, remaining_touches);
@@ -86,7 +93,7 @@ void *enroll_thread_loop()
             else if (ret == 0) {
 
                 uint32_t print_id = 0;
-                int print_index = fpc_enroll_end(&print_id);
+                int print_index = fpc_enroll_end(sdev->fpc, &print_id);
 
                 if (print_index < 0){
                     ALOGE("%s : Error getting new print index : %d", __func__,print_index);
@@ -97,16 +104,16 @@ void *enroll_thread_loop()
                     break;
                 }
 
-                uint32_t db_length = fpc_get_user_db_length();
+                uint32_t db_length = fpc_get_user_db_length(sdev->fpc);
                 ALOGI("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
-                fpc_store_user_db(db_length, db_path);
+                fpc_store_user_db(sdev->fpc, db_length, sdev->db_path);
 
                 ALOGI("%s : Got print id : %lu", __func__,(unsigned long) print_id);
 
                 fingerprint_msg_t msg;
                 msg.type = FINGERPRINT_TEMPLATE_ENROLLING;
                 msg.data.enroll.finger.fid = print_id;
-                msg.data.enroll.finger.gid = fpc_gid;
+                msg.data.enroll.finger.gid = sdev->gid;
                 msg.data.enroll.samples_remaining = 0;
                 msg.data.enroll.msg = 0;
                 callback(&msg);
@@ -121,40 +128,44 @@ void *enroll_thread_loop()
                 break;
             }
         }
-        pthread_mutex_lock(&lock);
-        if (!auth_thread_running) {
-            pthread_mutex_unlock(&lock);
+        pthread_mutex_lock(&sdev->lock);
+        if (!sdev->worker.thread_running) {
+            pthread_mutex_unlock(&sdev->lock);
             break;
         }
-        pthread_mutex_unlock(&lock);
+        pthread_mutex_unlock(&sdev->lock);
     }
 
     uint32_t print_id = 0;
     ALOGI("%s : finishing",__func__);
 
-    pthread_mutex_lock(&lock);
-    auth_thread_running = false;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    sdev->worker.thread_running = false;
+    pthread_mutex_unlock(&sdev->lock);
     return NULL;
 }
 
 
-void *auth_thread_loop()
+void *auth_thread_loop(void *arg)
 {
     ALOGI("%s", __func__);
-    fpc_auth_start();
+
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)arg;
+    fingerprint_notify_t callback = sdev->device.notify;
+
+    fpc_auth_start(sdev->fpc);
 
     int status = 1;
 
-    while((status = fpc_capture_image()) >= 0 ) {
+    while((status = fpc_capture_image(sdev->fpc)) >= 0 ) {
         ALOGD("%s : Got Input with status %d", __func__, status);
 
-        pthread_mutex_lock(&lock);
-        if (!auth_thread_running) {
-            pthread_mutex_unlock(&lock);
+        pthread_mutex_lock(&sdev->lock);
+        if (!sdev->worker.thread_running ) {
+            pthread_mutex_unlock(&sdev->lock);
             break;
         }
-        pthread_mutex_unlock(&lock);
+        pthread_mutex_unlock(&sdev->lock);
 
         if(status >= 1000)
             continue;
@@ -169,7 +180,7 @@ void *auth_thread_loop()
         if (status == FINGERPRINT_ACQUIRED_GOOD) {
 
             uint32_t print_id = 0;
-            int verify_state = fpc_auth_step(&print_id);
+            int verify_state = fpc_auth_step(sdev->fpc, &print_id);
             ALOGI("%s : Auth step = %d", __func__, verify_state);
 
             if (verify_state >= 0) {
@@ -178,7 +189,7 @@ void *auth_thread_loop()
                     ALOGI("%s : Got print id : %u", __func__, print_id);
 
                     hw_auth_token_t hat;
-                    fpc_get_hw_auth_obj(&hat, sizeof(hw_auth_token_t));
+                    fpc_get_hw_auth_obj(sdev->fpc, &hat, sizeof(hw_auth_token_t));
 
                     ALOGI("%s : hat->challenge %" PRIu64, __func__, hat.challenge);
                     ALOGI("%s : hat->user_id %" PRIu64, __func__, hat.user_id);
@@ -189,7 +200,7 @@ void *auth_thread_loop()
 
                     fingerprint_msg_t msg;
                     msg.type = FINGERPRINT_AUTHENTICATED;
-                    msg.data.authenticated.finger.gid = fpc_gid;
+                    msg.data.authenticated.finger.gid = sdev->gid;
                     msg.data.authenticated.finger.fid = print_id;
 
                     msg.data.authenticated.hat = hat;
@@ -201,18 +212,19 @@ void *auth_thread_loop()
         }
     }
 
-    fpc_auth_end();
+    fpc_auth_end(sdev->fpc);
     ALOGI("%s : finishing",__func__);
 
-    pthread_mutex_lock(&lock);
-    auth_thread_running = false;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    sdev->worker.thread_running  = false;
+    pthread_mutex_unlock(&sdev->lock);
     return NULL;
 }
 
 static int fingerprint_close(hw_device_t *dev)
 {
-    fpc_close();
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    fpc_close(&sdev->fpc);
     if (dev) {
         free(dev);
         return 0;
@@ -221,23 +233,24 @@ static int fingerprint_close(hw_device_t *dev)
     }
 }
 
-static uint64_t fingerprint_pre_enroll(struct fingerprint_device __attribute__((unused)) *dev)
+static uint64_t fingerprint_pre_enroll(struct fingerprint_device *dev)
 {
-    challenge = fpc_load_auth_challenge();
-    ALOGI("%s : Challenge is : %jd",__func__,challenge);
-    return challenge;
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    sdev->challenge = fpc_load_auth_challenge(sdev->fpc);
+    ALOGI("%s : Challenge is : %jd",__func__, sdev->challenge);
+    return sdev->challenge;
 }
 
-static int fingerprint_enroll(struct fingerprint_device __attribute__((unused)) *dev,
+static int fingerprint_enroll(struct fingerprint_device *dev,
                               const hw_auth_token_t *hat,
                               uint32_t __attribute__((unused)) gid,
                               uint32_t __attribute__((unused)) timeout_sec)
 {
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
 
-
-    pthread_mutex_lock(&lock);
-    bool thread_running = auth_thread_running;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    bool thread_running = sdev->worker.thread_running ;
+    pthread_mutex_unlock(&sdev->lock);
 
     if (thread_running) {
         ALOGE("%s : Error, thread already running\n", __func__);
@@ -252,15 +265,15 @@ static int fingerprint_enroll(struct fingerprint_device __attribute__((unused)) 
     ALOGI("%s : hat->timestamp %lu",__func__,(unsigned long) hat->timestamp);
     ALOGI("%s : hat size %lu",__func__,(unsigned long) sizeof(hw_auth_token_t));
 
-    fpc_verify_auth_challenge((void*) hat, sizeof(hw_auth_token_t));
+    fpc_verify_auth_challenge(sdev->fpc, (void*) hat, sizeof(hw_auth_token_t));
 
-    pthread_mutex_lock(&lock);
-    auth_thread_running = true;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    sdev->worker.thread_running  = true;
+    pthread_mutex_unlock(&sdev->lock);
 
-    if(pthread_create(&thread, NULL, enroll_thread_loop, NULL)) {
+    if(pthread_create(&sdev->worker.thread, NULL, enroll_thread_loop, (void*)sdev)) {
         ALOGE("%s : Error creating thread\n", __func__);
-        auth_thread_running = false;
+        sdev->worker.thread_running  = false;
         return FINGERPRINT_ERROR;
     }
 
@@ -268,35 +281,36 @@ static int fingerprint_enroll(struct fingerprint_device __attribute__((unused)) 
 
 }
 
-static uint64_t fingerprint_get_auth_id(struct fingerprint_device __attribute__((unused)) *dev)
+static uint64_t fingerprint_get_auth_id(struct fingerprint_device *dev)
 {
-
-    uint64_t id = fpc_load_db_id();
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    uint64_t id = fpc_load_db_id(sdev->fpc);
     ALOGI("%s : ID : %jd",__func__,id );
     return id;
 
 }
 
-static int fingerprint_cancel(struct fingerprint_device __attribute__((unused)) *dev)
+static int fingerprint_cancel(struct fingerprint_device *dev)
 {
     ALOGI("%s : +",__func__);
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
 
-    pthread_mutex_lock(&lock);
-    bool thread_running = auth_thread_running;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    bool thread_running = sdev->worker.thread_running ;
+    pthread_mutex_unlock(&sdev->lock);
 
     ALOGI("%s : check thread running",__func__);
-    if (!auth_thread_running) {
+    if (!sdev->worker.thread_running ) {
         ALOGI("%s : - (thread not running)",__func__);
         return 0;
     }
 
-    pthread_mutex_lock(&lock);
-    auth_thread_running = false;
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_lock(&sdev->lock);
+    sdev->worker.thread_running  = false;
+    pthread_mutex_unlock(&sdev->lock);
 
     ALOGI("%s : join running thread",__func__);
-    pthread_join(thread, NULL);
+    pthread_join(sdev->worker.thread, NULL);
 
     ALOGI("%s : -",__func__);
 
@@ -308,21 +322,22 @@ static int fingerprint_cancel(struct fingerprint_device __attribute__((unused)) 
     return 0;
 }
 
-static int fingerprint_remove(struct fingerprint_device __attribute__((unused)) *dev,
+static int fingerprint_remove(struct fingerprint_device  *dev,
                               uint32_t gid, uint32_t fid)
 {
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    fingerprint_notify_t callback = sdev->device.notify;
 
-
-    if (fpc_del_print_id(fid) == 0){
+    if (fpc_del_print_id(sdev->fpc, fid) == 0){
         fingerprint_msg_t msg;
         msg.type = FINGERPRINT_TEMPLATE_REMOVED;
         msg.data.removed.finger.fid = fid;
         msg.data.removed.finger.gid = gid;
         callback(&msg);
 
-        uint32_t db_length = fpc_get_user_db_length();
+        uint32_t db_length = fpc_get_user_db_length(sdev->fpc);
         ALOGD("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
-        fpc_store_user_db(db_length, db_path);
+        fpc_store_user_db(sdev->fpc, db_length, sdev->db_path);
         return 0;
     } else {
         fingerprint_msg_t msg;
@@ -334,25 +349,26 @@ static int fingerprint_remove(struct fingerprint_device __attribute__((unused)) 
     }
 }
 
-static int fingerprint_set_active_group(struct fingerprint_device __attribute__((unused)) *dev,
+static int fingerprint_set_active_group(struct fingerprint_device *dev,
                                         uint32_t gid, const char *store_path)
 {
     int result;
-    // FIXME: suzu hal uses a single db with multiple gid. Support this!
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+
     #ifdef FPC_DB_PER_GID
     sprintf(db_path,"%s/data_%d.db", store_path, gid);
     #else
-    sprintf(db_path,"%s/user.db", store_path);
+    sprintf(sdev->db_path,"%s/user.db", store_path);
     #endif
-    fpc_gid = gid;
+    sdev->gid = gid;
 
-    ALOGI("%s : storage path set to : %s",__func__, db_path);
-    if((result = fpc_load_user_db(db_path)) != 0)
+    ALOGI("%s : storage path set to : %s",__func__, sdev->db_path);
+    if((result = fpc_load_user_db(sdev->fpc, sdev->db_path)) != 0)
     {
         ALOGE("Error loading user database: %d\n", result);
         return result;
     }
-    if((result = fpc_set_gid(gid)) != 0)
+    if((result = fpc_set_gid(sdev->fpc, gid)) != 0)
     {
         ALOGE("Error setting current gid: %d\n", result);
     }
@@ -364,10 +380,13 @@ static int fingerprint_set_active_group(struct fingerprint_device __attribute__(
 static int fingerprint_enumerate(struct fingerprint_device *dev)
 {
     ALOGE(__func__);
-    uint32_t print_count = fpc_get_print_count();
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    fingerprint_notify_t callback = sdev->device.notify;
+
+    uint32_t print_count = fpc_get_print_count(sdev->fpc);
     ALOGD("%s : print count is : %u", __func__, print_count);
 
-    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(print_count);
+    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(sdev->fpc, print_count);
     if(print_indexs.print_count != print_count)
     {
         ALOGW("Print count mismatch: %d != %d", print_count, print_indexs.print_count);
@@ -378,21 +397,22 @@ static int fingerprint_enumerate(struct fingerprint_device *dev)
         fingerprint_msg_t msg;
         msg.type = FINGERPRINT_TEMPLATE_ENUMERATING;
         msg.data.enumerated.finger.fid = print_indexs.prints[i];
-        msg.data.enumerated.finger.gid = fpc_gid;
+        msg.data.enumerated.finger.gid = sdev->gid;
         msg.data.enumerated.remaining_templates = (uint32_t)(print_indexs.print_count - i - 1);
         callback(&msg);
     }
     return 0;
 }
 #else
-static int fingerprint_enumerate(struct fingerprint_device __attribute__((unused)) *dev,
+static int fingerprint_enumerate(struct fingerprint_device *dev,
                                  fingerprint_finger_id_t *results,
                                  uint32_t *max_size)
 {
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
 
-    uint32_t print_count = fpc_get_print_count();
+    uint32_t print_count = fpc_get_print_count(sdev->fpc);
     ALOGD("%s : print count is : %u", __func__, print_count);
-    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(print_count);
+    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(sdev->fpc, print_count);
 
     if (*max_size == 0) {
         *max_size = print_count;
@@ -401,7 +421,7 @@ static int fingerprint_enumerate(struct fingerprint_device __attribute__((unused
             ALOGD("%s : found print : %lu at index %zu", __func__,(unsigned long) print_indexs.prints[i], i);
 
             results[i].fid = print_indexs.prints[i];
-            results[i].gid = fpc_gid;
+            results[i].gid = sdev->gid;
         }
     }
 
@@ -413,21 +433,25 @@ static int fingerprint_authenticate(struct fingerprint_device __attribute__((unu
                                     uint64_t __attribute__((unused)) operation_id, __attribute__((unused)) uint32_t gid)
 {
 
-    if (auth_thread_running) {
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+
+    pthread_mutex_lock(&sdev->lock);
+    if (sdev->worker.thread_running) {
         ALOGE("%s : Error, thread already running\n", __func__);
+        pthread_mutex_unlock(&sdev->lock);
         return -1;
     }
 
-    pthread_mutex_lock(&lock);
-    auth_thread_running = true;
-    pthread_mutex_unlock(&lock);
+
+    sdev->worker.thread_running = true;
+    pthread_mutex_unlock(&sdev->lock);
 
     // FIXME: Verify whether this needs to run on each
-    fpc_set_auth_challenge(0);
+    fpc_set_auth_challenge(sdev->fpc, 0);
 
-    if(pthread_create(&thread, NULL, auth_thread_loop, NULL)) {
+    if(pthread_create(&sdev->worker.thread, NULL, auth_thread_loop, (void*)sdev)) {
         ALOGE("%s : Error creating thread\n", __func__);
-        auth_thread_running = false;
+        sdev->worker.thread_running = false;
         return FINGERPRINT_ERROR;
     }
 
@@ -437,9 +461,10 @@ static int fingerprint_authenticate(struct fingerprint_device __attribute__((unu
 static int set_notify_callback(struct fingerprint_device *dev,
                                fingerprint_notify_t notify)
 {
-    /* Decorate with locks */
+    sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    pthread_mutex_lock(&sdev->lock);
     dev->notify = notify;
-    callback = notify;
+    pthread_mutex_unlock(&sdev->lock);
     return 0;
 }
 
@@ -453,15 +478,18 @@ static int fingerprint_open(const hw_module_t* module, const char __attribute__(
         ALOGE("NULL device on open");
         return -EINVAL;
     }
+    fpc_imp_data_t *fpc_data = NULL;
 
-
-    if (fpc_init() < 0) {
+    if (fpc_init(&fpc_data) < 0) {
         ALOGE("Could not init FPC device");
         return -EINVAL;
     }
 
-    fingerprint_device_t *dev = malloc(sizeof(fingerprint_device_t));
-    memset(dev, 0, sizeof(fingerprint_device_t));
+    sony_fingerprint_device_t *sdev = malloc(sizeof(sony_fingerprint_device_t));
+    fingerprint_device_t *dev = (fingerprint_device_t*)sdev;
+
+    memset(sdev, 0, sizeof(sony_fingerprint_device_t));
+    sdev->fpc = fpc_data;
 
     dev->common.tag = HARDWARE_DEVICE_TAG;
 #if PLATFORM_SDK_VERSION >= 24

--- a/fpc_imp.h
+++ b/fpc_imp.h
@@ -28,35 +28,39 @@ typedef struct
     uint32_t prints[MAX_FINGERPRINTS];
 } fpc_fingerprint_index_t;
 
-int64_t fpc_load_db_id(); //load db ID, used as authenticator ID in android
-int64_t fpc_load_auth_challenge(); //genertate and load an auth challenge for pre enroll
-err_t fpc_set_auth_challenge(int64_t challenge); //set auth challenge during authenticate
-err_t fpc_verify_auth_challenge(void* hat, uint32_t size); //verify auth challenge before enroll (ensure its still valid)
-err_t fpc_get_hw_auth_obj(void * buffer, uint32_t length); //get HAT object (copied into buffer) on authenticate
+typedef struct fpc_imp_data_t {
+
+} fpc_imp_data_t;
+
+int64_t fpc_load_db_id(fpc_imp_data_t *data); //load db ID, used as authenticator ID in android
+int64_t fpc_load_auth_challenge(fpc_imp_data_t *data); //genertate and load an auth challenge for pre enroll
+err_t fpc_set_auth_challenge(fpc_imp_data_t *data, int64_t challenge); //set auth challenge during authenticate
+err_t fpc_verify_auth_challenge(fpc_imp_data_t *data, void* hat, uint32_t size); //verify auth challenge before enroll (ensure its still valid)
+err_t fpc_get_hw_auth_obj(fpc_imp_data_t *data, void * buffer, uint32_t length); //get HAT object (copied into buffer) on authenticate
 // FIXME: This should probably only exist inside kitakami implementation?
 // Make all functions return resolved index->id
 // FIXME: Internal to kitakami:
-err_t fpc_get_print_id(int id);
-err_t fpc_get_print_count(); //get count of enrolled prints
-err_t fpc_del_print_id(uint32_t id); //delete print at index
-fpc_fingerprint_index_t fpc_get_print_ids(uint32_t count); //get list of print index's available
-fpc_fingerprint_index_t fpc_get_print_index(uint32_t count); //get list of print index's available
-err_t fpc_wait_for_finger(); //wait for event IRQ on print reader
-err_t fpc_capture_image(); //capture image ready for enroll / auth
-err_t fpc_enroll_step(uint32_t *remaining_touches); //step forward enroll & process image (only available if capture image returns OK)
+err_t fpc_get_print_id(fpc_imp_data_t *data, int id);
+err_t fpc_get_print_count(fpc_imp_data_t *data); //get count of enrolled prints
+err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id); //delete print at index
+fpc_fingerprint_index_t fpc_get_print_ids(fpc_imp_data_t *data, uint32_t count); //get list of print index's available
+fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data, uint32_t count); //get list of print index's available
+err_t fpc_wait_for_finger(fpc_imp_data_t *data); //wait for event IRQ on print reader
+err_t fpc_capture_image(fpc_imp_data_t *data); //capture image ready for enroll / auth
+err_t fpc_enroll_step(fpc_imp_data_t *data, uint32_t *remaining_touches); //step forward enroll & process image (only available if capture image returns OK)
 // FIXME: index of next print should be retrieved using fpc_get-print_count internally in kitakami impl.
-err_t fpc_enroll_start(int print_index); //start enrollment
-err_t fpc_enroll_end(uint32_t *print_id); //end enrollment
-err_t fpc_auth_start(); //start auth
-err_t fpc_auth_step(uint32_t *print_id); //step forward auth & process image (only available if capture image returns OK)
-err_t fpc_auth_end(); //end auth
+err_t fpc_enroll_start(fpc_imp_data_t *data, int print_index); //start enrollment
+err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id); //end enrollment
+err_t fpc_auth_start(fpc_imp_data_t *data); //start auth
+err_t fpc_auth_step(fpc_imp_data_t *data, uint32_t *print_id); //step forward auth & process image (only available if capture image returns OK)
+err_t fpc_auth_end(fpc_imp_data_t *data); //end auth
 // FIXME: This should be internal to kitakami implementation
-err_t fpc_get_user_db_length(); //get size of working db
-err_t fpc_set_gid(uint32_t gid);
-err_t fpc_load_user_db(char* path); //load user DB into TZ app from storage
+err_t fpc_get_user_db_length(fpc_imp_data_t *data); //get size of working db
+err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid);
+err_t fpc_load_user_db(fpc_imp_data_t *data, char* path); //load user DB into TZ app from storage
 // FIXME: length should be fetched internally in kitakami implementation
-err_t fpc_store_user_db(uint32_t length, char* path); //store running TZ db
-err_t fpc_close(); //close this implementation
-err_t fpc_init(); //init sensor
+err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t length, char* path); //store running TZ db
+err_t fpc_close(fpc_imp_data_t **data); //close this implementation
+err_t fpc_init(fpc_imp_data_t **data); //init sensor
 
 #endif

--- a/fpc_imp.h
+++ b/fpc_imp.h
@@ -58,6 +58,7 @@ err_t fpc_auth_end(fpc_imp_data_t *data); //end auth
 err_t fpc_get_user_db_length(fpc_imp_data_t *data); //get size of working db
 err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid);
 err_t fpc_load_user_db(fpc_imp_data_t *data, char* path); //load user DB into TZ app from storage
+err_t fpc_load_empty_db(fpc_imp_data_t *data);
 // FIXME: length should be fetched internally in kitakami implementation
 err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t length, char* path); //store running TZ db
 err_t fpc_close(fpc_imp_data_t **data); //close this implementation

--- a/fpc_imp_kitakami.c
+++ b/fpc_imp_kitakami.c
@@ -147,12 +147,12 @@ int fpc_set_auth_challenge(int64_t __unused challenge)
     return send_normal_command(FPC_SET_AUTH_CHALLENGE,0,mFPCHandle);
 }
 
-int64_t fpc_load_auth_challenge()
+int64_t fpc_load_auth_challenge(fpc_imp_data_t *data)
 {
     return get_int64_command(FPC_GET_AUTH_CHALLENGE,0,mFPCHandle);
 }
 
-int64_t fpc_load_db_id()
+int64_t fpc_load_db_id(fpc_imp_data_t *data)
 {
     return get_int64_command(FPC_GET_DB_ID,0,mFPCHandle);
 }

--- a/fpc_imp_loire.c
+++ b/fpc_imp_loire.c
@@ -29,17 +29,19 @@
 #define LOG_NDEBUG 0
 
 #include <cutils/log.h>
+#include <limits.h>
 
 #define SPI_CLK_FILE "/sys/bus/spi/devices/spi0.1/clk_enable"
 #define SPI_PREP_FILE "/sys/devices/soc/fpc1145_device/spi_prepare"
 #define SPI_WAKE_FILE "/sys/devices/soc/fpc1145_device/wakeup_enable"
 #define SPI_IRQ_FILE "/sys/devices/soc/fpc1145_device/irq"
 
-static struct QSEECom_handle * mFPC_handle;
-static struct QSEECom_handle * mKeymasterHandle;
-
-static struct qsee_handle_t* qsee_handle = NULL;
-uint32_t auth_id = 0;
+typedef struct {
+    struct fpc_imp_data_t data;
+    struct QSEECom_handle *fpc_handle;
+    struct qsee_handle_t* qsee_handle;
+    uint32_t auth_id;
+} fpc_data_t;
 
 static err_t poll_irq(char *path)
 {
@@ -110,8 +112,9 @@ static const char *fpc_error_str(int err)
 }
 
 
-err_t send_modified_command_to_tz(struct QSEECom_handle * handle, struct qcom_km_ion_info_t ihandle)
+err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t ihandle)
 {
+    struct QSEECom_handle *handle = ldata->fpc_handle;
 
     fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) handle->ion_sbuffer;
     void *rec_cmd = handle->ion_sbuffer + 64;
@@ -125,7 +128,7 @@ err_t send_modified_command_to_tz(struct QSEECom_handle * handle, struct qcom_km
     send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
     uint32_t length = (ihandle.sbuf_len + 4095) & (~4095);
     send_cmd->length = length;
-    int result = qsee_handle->send_modified_cmd(handle,send_cmd,64,rec_cmd,64,&ion_fd_info);
+    int result = ldata->qsee_handle->send_modified_cmd(handle,send_cmd,64,rec_cmd,64,&ion_fd_info);
 
     if(result)
     {
@@ -142,14 +145,14 @@ err_t send_modified_command_to_tz(struct QSEECom_handle * handle, struct qcom_km
     return result;
 }
 
-err_t send_normal_command(struct QSEECom_handle * handle, int command)
+err_t send_normal_command(fpc_data_t *ldata, int command)
 {
     struct qcom_km_ion_info_t ihandle;
 
 
     ihandle.ion_fd = 0;
 
-    if (qsee_handle->ion_alloc(&ihandle, 0x40) <0) {
+    if (ldata->qsee_handle->ion_alloc(&ihandle, 0x40) <0) {
         ALOGE("ION allocation  failed");
         return -1;
     }
@@ -161,20 +164,20 @@ err_t send_normal_command(struct QSEECom_handle * handle, int command)
     send_cmd->cmd_id = command;
     send_cmd->ret_val = 0x0;
 
-    int ret = send_modified_command_to_tz(handle, ihandle);
+    int ret = send_modified_command_to_tz(ldata, ihandle);
 
     if(!ret) {
         ret = send_cmd->ret_val;
     }
 
-    qsee_handle->ion_free(&ihandle);
+    ldata->qsee_handle->ion_free(&ihandle);
     return ret;
 }
 
-err_t send_buffer_command(struct QSEECom_handle * handle, uint32_t group_id, uint32_t cmd_id, const uint8_t *buffer, uint32_t length)
+err_t send_buffer_command(fpc_data_t *ldata, uint32_t group_id, uint32_t cmd_id, const uint8_t *buffer, uint32_t length)
 {
     struct qcom_km_ion_info_t ihandle;
-    if (qsee_handle->ion_alloc(&ihandle, length + sizeof(fpc_send_buffer_t)) <0) {
+    if (ldata->qsee_handle->ion_alloc(&ihandle, length + sizeof(fpc_send_buffer_t)) <0) {
         ALOGE("ION allocation  failed");
         return -1;
     }
@@ -185,21 +188,21 @@ err_t send_buffer_command(struct QSEECom_handle * handle, uint32_t group_id, uin
     cmd_data->length = length;
     memcpy(&cmd_data->data, buffer, length);
 
-    if(send_modified_command_to_tz(handle, ihandle) < 0) {
+    if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
 
     int result = cmd_data->status;
-    qsee_handle->ion_free(&ihandle);
+    ldata->qsee_handle->ion_free(&ihandle);
     return result;
 }
 
 
-err_t send_command_result_buffer(struct QSEECom_handle * handle, uint32_t group_id, uint32_t cmd_id, uint8_t *buffer, uint32_t length)
+err_t send_command_result_buffer(fpc_data_t *ldata, uint32_t group_id, uint32_t cmd_id, uint8_t *buffer, uint32_t length)
 {
     struct qcom_km_ion_info_t ihandle;
-    if (qsee_handle->ion_alloc(&ihandle, length + sizeof(fpc_send_buffer_t)) <0) {
+    if (ldata->qsee_handle->ion_alloc(&ihandle, length + sizeof(fpc_send_buffer_t)) <0) {
         ALOGE("ION allocation  failed");
         return -1;
     }
@@ -209,52 +212,53 @@ err_t send_command_result_buffer(struct QSEECom_handle * handle, uint32_t group_
     keydata_cmd->cmd_id = cmd_id;
     keydata_cmd->length = length;
 
-    if(send_modified_command_to_tz(handle, ihandle) < 0) {
+    if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
     memcpy(buffer, &keydata_cmd->data[0], length);
 
     int result = keydata_cmd->status;
-    qsee_handle->ion_free(&ihandle);
+    ldata->qsee_handle->ion_free(&ihandle);
     return result;
 }
 
-err_t send_custom_cmd(struct QSEECom_handle * handle, void *buffer, uint32_t len)
+err_t send_custom_cmd(fpc_data_t *ldata, void *buffer, uint32_t len)
 {
     ALOGD(__func__);
     struct qcom_km_ion_info_t ihandle;
 
-    if (qsee_handle->ion_alloc(&ihandle, len) <0) {
+    if (ldata->qsee_handle->ion_alloc(&ihandle, len) <0) {
         ALOGE("ION allocation  failed");
         return -1;
     }
 
     memcpy(ihandle.ion_sbuffer, buffer, len);
 
-    if(send_modified_command_to_tz(handle, ihandle) < 0) {
+    if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
 
     // Copy back result
     memcpy(buffer, ihandle.ion_sbuffer, len);
-    qsee_handle->ion_free(&ihandle);
+    ldata->qsee_handle->ion_free(&ihandle);
 
     return 0;
 };
 
 
-err_t fpc_set_auth_challenge(int64_t challenge)
+err_t fpc_set_auth_challenge(fpc_imp_data_t *data, int64_t challenge)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
 
     fpc_send_auth_cmd_t auth_cmd = {0};
     auth_cmd.group_id = FPC_GROUP_FPCDATA;
     auth_cmd.cmd_id = FPC_SET_AUTH_CHALLENGE;
     auth_cmd.challenge = challenge;
 
-    if(send_custom_cmd(mFPC_handle, &auth_cmd, sizeof(auth_cmd)) < 0) {
+    if(send_custom_cmd(ldata, &auth_cmd, sizeof(auth_cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
@@ -263,15 +267,15 @@ err_t fpc_set_auth_challenge(int64_t challenge)
     return auth_cmd.status;
 }
 
-int64_t fpc_load_auth_challenge()
+int64_t fpc_load_auth_challenge(fpc_imp_data_t *data)
 {
     ALOGD(__func__);
-
+    fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_load_auth_challenge_t cmd = {0};
     cmd.group_id = FPC_GROUP_FPCDATA;
     cmd.cmd_id = FPC_GET_AUTH_CHALLENGE;
 
-    if(send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd)) < 0) {
+    if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
@@ -283,28 +287,32 @@ int64_t fpc_load_auth_challenge()
     return cmd.challenge;
 }
 
-int64_t fpc_load_db_id()
+int64_t fpc_load_db_id(fpc_imp_data_t *data)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
     fpc_get_db_id_cmd_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_GET_TEMPLATE_ID;
 
-    if(send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd)) < 0) {
+    if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to TZ\n");
         return -1;
     }
     return cmd.auth_id;
 }
 
-err_t fpc_get_hw_auth_obj(void * buffer, uint32_t length)
+err_t fpc_get_hw_auth_obj(fpc_imp_data_t *data, void * buffer, uint32_t length)
 {
     ALOGD(__func__);
     fpc_get_auth_result_t cmd = {0};
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
     cmd.group_id = FPC_GROUP_FPCDATA;
     cmd.cmd_id = FPC_GET_AUTH_RESULT;
     cmd.length = AUTH_RESULT_LENGTH;
-    if(send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd)) < 0) {
+    if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
     }
@@ -323,24 +331,27 @@ err_t fpc_get_hw_auth_obj(void * buffer, uint32_t length)
   return 0;
 }
 
-err_t fpc_verify_auth_challenge(void* hat, uint32_t size)
+err_t fpc_verify_auth_challenge(fpc_imp_data_t *data, void* hat, uint32_t size)
 {
     ALOGD(__func__);
-    int ret = send_buffer_command(mFPC_handle, FPC_GROUP_FPCDATA, FPC_AUTHORIZE_ENROL, hat, size);
+    fpc_data_t *ldata = (fpc_data_t*)data;
+    int ret = send_buffer_command(ldata, FPC_GROUP_FPCDATA, FPC_AUTHORIZE_ENROL, hat, size);
     ALOGE("verify auth challenge: %d\n", ret);
     return ret;
 }
 
 
-err_t fpc_del_print_id(uint32_t id)
+err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
     fpc_fingerprint_delete_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_DELETE_FINGERPRINT;
     cmd.fingerprint_id = id;
 
-    int ret = send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd));
+    int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0)
     {
         ALOGE("Error sending command: %d\n", ret);
@@ -349,26 +360,29 @@ err_t fpc_del_print_id(uint32_t id)
     return cmd.status;
 }
 
-err_t fpc_wait_finger_lost()
+err_t fpc_wait_finger_lost(fpc_imp_data_t *data)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
     int result;
-    result = send_normal_command(mFPC_handle, FPC_WAIT_FINGER_LOST);
+
+    result = send_normal_command(ldata, FPC_WAIT_FINGER_LOST);
     if(result > 0)
         return 0;
 
     return -1;
 }
 
-err_t fpc_wait_finger_down()
+err_t fpc_wait_finger_down(fpc_imp_data_t *data)
 {
     ALOGD(__func__);
     int result=-1;
     int i;
+    fpc_data_t *ldata = (fpc_data_t*)data;
 
 //    while(1)
     {
-        result = send_normal_command(mFPC_handle, FPC_WAIT_FINGER_DOWN);
+        result = send_normal_command(ldata, FPC_WAIT_FINGER_DOWN);
         ALOGE("Wait finger down result: %d\n", result);
         if(result)
             return result;
@@ -378,7 +392,7 @@ err_t fpc_wait_finger_down()
                 return -1;
         }
 
-        result = send_normal_command(mFPC_handle, FPC_GET_FINGER_STATUS);
+        result = send_normal_command(ldata, FPC_GET_FINGER_STATUS);
         if(result < 0)
         {
             ALOGE("Get finger status failed: %d\n", result);
@@ -392,23 +406,26 @@ err_t fpc_wait_finger_down()
 }
 
 // Attempt to capture image
-err_t fpc_capture_image()
+err_t fpc_capture_image(fpc_imp_data_t *data)
 {
     ALOGD(__func__);
+
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
     if (device_enable() < 0) {
         ALOGE("Error starting device\n");
         return -1;
     }
 
-    int ret = fpc_wait_finger_lost();
+    int ret = fpc_wait_finger_lost(data);
     if(!ret)
     {
         ALOGE("Finger lost as expected\n");
-        ret = fpc_wait_finger_down();
+        ret = fpc_wait_finger_down(data);
         if(!ret)
         {
             ALOGE("Finger down, capturing image\n");
-            ret = send_normal_command(mFPC_handle, FPC_CAPTURE_IMAGE);
+            ret = send_normal_command(ldata, FPC_CAPTURE_IMAGE);
             ALOGE("Image capture result :%d\n", ret);
         } else
             ret = 1001;
@@ -421,18 +438,19 @@ err_t fpc_capture_image()
         return -1;
     }
 
-    send_normal_command(mFPC_handle, FPC_INIT);
+    send_normal_command(ldata, FPC_INIT);
     return ret;
 }
 
-err_t fpc_enroll_step(uint32_t *remaining_touches)
+err_t fpc_enroll_step(fpc_imp_data_t *data, uint32_t *remaining_touches)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_enrol_step_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_ENROL_STEP;
 
-    int ret = send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd));
+    int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret <0)
     {
         ALOGE("Error sending command: %d\n", ret);
@@ -447,10 +465,11 @@ err_t fpc_enroll_step(uint32_t *remaining_touches)
     return cmd.status;
 }
 
-err_t fpc_enroll_start(int __unused print_index)
+err_t fpc_enroll_start(fpc_imp_data_t * data, int __unused print_index)
 {
     ALOGD(__func__);
-    int ret = send_normal_command(mFPC_handle, FPC_BEGIN_ENROL);
+    fpc_data_t *ldata = (fpc_data_t*)data;
+    int ret = send_normal_command(ldata, FPC_BEGIN_ENROL);
     if(ret < 0) {
         ALOGE("Error beginning enrol: %d\n", ret);
         return -1;
@@ -458,14 +477,15 @@ err_t fpc_enroll_start(int __unused print_index)
     return ret;
 }
 
-err_t fpc_enroll_end(uint32_t *print_id)
+err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id)
 {
     ALOGD(__func__);
+    fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_end_enrol_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_END_ENROL;
 
-    if(send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd)) < 0) {
+    if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending enrol command\n");
         return -1;
     }
@@ -479,18 +499,19 @@ err_t fpc_enroll_end(uint32_t *print_id)
 }
 
 
-err_t fpc_auth_start()
+err_t fpc_auth_start(fpc_imp_data_t __unused  *data)
 {
     ALOGD(__func__);
     return 0;
 }
 
-err_t fpc_auth_step(uint32_t *print_id)
+err_t fpc_auth_step(fpc_imp_data_t *data, uint32_t *print_id)
 {
+    fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_send_identify_t identify_cmd = {0};
     identify_cmd.commandgroup = FPC_GROUP_NORMAL;
     identify_cmd.command = FPC_IDENTIFY;
-    int result = send_custom_cmd(mFPC_handle, &identify_cmd, sizeof(identify_cmd));
+    int result = send_custom_cmd(ldata, &identify_cmd, sizeof(identify_cmd));
     if(result)
     {
         ALOGE("Error identifying: %d || %d\n", result, identify_cmd.status);
@@ -504,31 +525,32 @@ err_t fpc_auth_step(uint32_t *print_id)
     return identify_cmd.status;
 }
 
-err_t fpc_auth_end()
+err_t fpc_auth_end(fpc_imp_data_t __unused *data)
 {
     ALOGD(__func__);
     return 0;
 }
 
 
-err_t fpc_get_print_count()
+err_t fpc_get_print_count(fpc_imp_data_t __unused *data)
 {
     ALOGD(__func__);
     return 0;
 }
 
 
-fpc_fingerprint_index_t fpc_get_print_index(uint32_t __unused count)
+fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data, uint32_t __unused count)
 {
     ALOGD(__func__);
-    fpc_fingerprint_index_t data = {0};
+    fpc_data_t *ldata = (fpc_data_t*)data;
+    fpc_fingerprint_index_t idx_data = {0};
     fpc_fingerprint_list_t cmd = {0};
     unsigned int i;
 
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_GET_FINGERPRINTS;
 
-    int ret = send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd));
+    int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0 || cmd.status != 0)
     {
         ALOGE("Error retrieving fingerprints\n");
@@ -537,27 +559,29 @@ fpc_fingerprint_index_t fpc_get_print_index(uint32_t __unused count)
     ALOGE("Found %d fingerprints\n", cmd.length);
     for(i=0; i<cmd.length; i++)
     {
-        data.prints[i] = cmd.fingerprints[i];
+        idx_data.prints[i] = cmd.fingerprints[i];
     }
 
-    return data;
+    return idx_data;
 }
 
 
-err_t fpc_get_user_db_length()
+err_t fpc_get_user_db_length(fpc_imp_data_t __unused *data)
 {
     ALOGD(__func__);
     return 0;
 }
 
 
-err_t fpc_load_user_db(char* path)
+err_t fpc_load_user_db(fpc_imp_data_t *data, char* path)
 {
     int result;
     struct stat sb;
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
     if(stat(path, &sb) == -1)
     {
-        result = send_normal_command(mFPC_handle, FPC_LOAD_EMPTY_DB);
+        result = send_normal_command(ldata, FPC_LOAD_EMPTY_DB);
         if(result)
         {
             ALOGE("Error creating new empty database: %d\n", result);
@@ -566,34 +590,35 @@ err_t fpc_load_user_db(char* path)
     } else
     {
        ALOGD("Loading user db from %s\n", path);
-        result = send_buffer_command(mFPC_handle, FPC_GROUP_DB, FPC_LOAD_DB, (const uint8_t*)path, (uint32_t)strlen(path)+1);
+        result = send_buffer_command(ldata, FPC_GROUP_DB, FPC_LOAD_DB, (const uint8_t*)path, (uint32_t)strlen(path)+1);
     }
     return result;
 }
 
-err_t fpc_set_gid(uint32_t gid)
+err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid)
 {
     int result;
+    fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_set_gid_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_SET_GID;
     cmd.gid = gid;
 
     ALOGD("Setting GID to %d\n", gid);
-    result = send_custom_cmd(mFPC_handle, &cmd, sizeof(cmd));
+    result = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(!result)
         result = cmd.status;
 
     return result;
 }
 
-err_t fpc_store_user_db(uint32_t __unused length, char* path)
+err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t __unused length, char* path)
 {
     ALOGD(__func__);
-
+    fpc_data_t *ldata = (fpc_data_t*)data;
     char temp_path[PATH_MAX];
     snprintf(temp_path, PATH_MAX - 1, "%s.tmp", path);
-    int ret = send_buffer_command(mFPC_handle, FPC_GROUP_DB, FPC_STORE_DB, (const uint8_t*)temp_path, (uint32_t)strlen(temp_path)+1);
+    int ret = send_buffer_command(ldata, FPC_GROUP_DB, FPC_STORE_DB, (const uint8_t*)temp_path, (uint32_t)strlen(temp_path)+1);
     if(ret < 0)
     {
         ALOGE("storing database failed: %d\n", ret);
@@ -607,48 +632,62 @@ err_t fpc_store_user_db(uint32_t __unused length, char* path)
     return ret;
 }
 
-err_t fpc_close()
+err_t fpc_close(fpc_imp_data_t **data)
 {
     ALOGD(__func__);
-    qsee_handle->shutdown_app(&mFPC_handle);
+    fpc_data_t *ldata = (fpc_data_t*)data;
+    ldata->qsee_handle->shutdown_app(&ldata->fpc_handle);
     if (device_disable() < 0) {
         ALOGE("Error stopping device\n");
         return -1;
     }
-    qsee_free_handle(&qsee_handle);
+    qsee_free_handle(&ldata->qsee_handle);
+    free(ldata);
+    *data = NULL;
     return 1;
 }
 
-err_t fpc_init()
+err_t fpc_init(fpc_imp_data_t **data)
 {
     int ret=0;
+
+    struct QSEECom_handle * mFPC_handle = NULL;
+    struct QSEECom_handle * mKeymasterHandle = NULL;
+    struct qsee_handle_t* qsee_handle = NULL;
+
     ALOGE("INIT FPC TZ APP\n");
     if(qsee_open_handle(&qsee_handle) != 0) {
         ALOGE("Error loading QSEECom library");
-        return -1;
+        goto err;
     }
 
     if (device_enable() < 0) {
         ALOGE("Error starting device\n");
-        return -1;
+        goto err_qsee;
     }
+
+    fpc_data_t *fpc_data = (fpc_data_t*)malloc(sizeof(fpc_data_t));
+    fpc_data->auth_id = 0;
 
     ALOGE("Starting app %s\n", KM_TZAPP_NAME);
     if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_NAME, 1024) < 0) {
         if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_ALT_NAME, 1024) < 0) {
             ALOGE("Could not load app %s or %s\n", KM_TZAPP_NAME, KM_TZAPP_ALT_NAME);
-            return -1;
+            goto err_alloc;
         }
     }
+    fpc_data->qsee_handle = qsee_handle;
 
 
     ALOGE("Starting app %s\n", FP_TZAPP_NAME);
     if (qsee_handle->load_trustlet(qsee_handle, &mFPC_handle, FP_TZAPP_PATH, FP_TZAPP_NAME, 128) < 0) {
         ALOGE("Could not load app : %s\n", FP_TZAPP_NAME);
-        return -1;
+        goto err_keymaster;
     }
 
-    if ((ret = send_normal_command(mFPC_handle, FPC_INIT)) != 0) {
+    fpc_data->fpc_handle = mFPC_handle;
+
+    if ((ret = send_normal_command(fpc_data, FPC_INIT)) != 0) {
         ALOGE("Error sending FPC_INIT to tz: %d\n", ret);
         return -1;
     }
@@ -663,9 +702,8 @@ err_t fpc_init()
 
     //Send command to keymaster
     if (qsee_handle->send_cmd(mKeymasterHandle, send_buf, 64, rec_buf, 1024-64) < 0) {
-        return -1;
+        goto err_keymaster;
     }
-
 
     keymaster_return_t* ret_data = (keymaster_return_t*) rec_buf;
 
@@ -680,9 +718,9 @@ err_t fpc_init()
     memcpy(keydata, data_buff, keylength);
 
     qsee_handle->shutdown_app(&mKeymasterHandle);
+    mKeymasterHandle = NULL;
 
-    int result = send_buffer_command(mFPC_handle, FPC_GROUP_FPCDATA, FPC_SET_KEY_DATA, keydata, keylength);
-    // TODO: Something about fingerprint database?
+    int result = send_buffer_command(fpc_data, FPC_GROUP_FPCDATA, FPC_SET_KEY_DATA, keydata, keylength);
 
     ALOGD("FPC_SET_KEY_DATA Result: %d\n", result);
     if(result != 0)
@@ -690,8 +728,21 @@ err_t fpc_init()
 
     if (device_disable() < 0) {
         ALOGE("Error stopping device\n");
-        return -1;
+        goto err_alloc;
     }
 
+    *data = (fpc_imp_data_t*)fpc_data;
+
     return 1;
+
+err_keymaster:
+    if(mKeymasterHandle != NULL)
+        qsee_handle->shutdown_app(&mKeymasterHandle);
+err_alloc:
+    if(fpc_data != NULL)
+        free(fpc_data);
+err_qsee:
+    qsee_free_handle(&qsee_handle);
+err:
+    return -1;
 }

--- a/fpc_imp_loire.c
+++ b/fpc_imp_loire.c
@@ -572,6 +572,19 @@ err_t fpc_get_user_db_length(fpc_imp_data_t __unused *data)
     return 0;
 }
 
+err_t fpc_load_empty_db(fpc_imp_data_t *data) {
+    err_t result;
+    fpc_data_t *ldata = (fpc_data_t*)data;
+
+    result = send_normal_command(ldata, FPC_LOAD_EMPTY_DB);
+    if(result)
+    {
+        ALOGE("Error creating new empty database: %d\n", result);
+        return result;
+    }
+    return 0;
+}
+
 
 err_t fpc_load_user_db(fpc_imp_data_t *data, char* path)
 {
@@ -579,19 +592,8 @@ err_t fpc_load_user_db(fpc_imp_data_t *data, char* path)
     struct stat sb;
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    if(stat(path, &sb) == -1)
-    {
-        result = send_normal_command(ldata, FPC_LOAD_EMPTY_DB);
-        if(result)
-        {
-            ALOGE("Error creating new empty database: %d\n", result);
-            return result;
-        }
-    } else
-    {
-       ALOGD("Loading user db from %s\n", path);
-        result = send_buffer_command(ldata, FPC_GROUP_DB, FPC_LOAD_DB, (const uint8_t*)path, (uint32_t)strlen(path)+1);
-    }
+    ALOGD("Loading user db from %s\n", path);
+    result = send_buffer_command(ldata, FPC_GROUP_DB, FPC_LOAD_DB, (const uint8_t*)path, (uint32_t)strlen(path)+1);
     return result;
 }
 


### PR DESCRIPTION
Get rid of all global variables and store them inside sane device structures.
This also makes handles clearly and enables future sharing of ION allocated memory in loire implementation.(instead of allocating on each call)