### PR TITLE
Add support for Tone 7.1 FPC Implementation

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -31,7 +31,11 @@ LOCAL_CFLAGS += -DFPC_DB_PER_GID
 endif
 
 ifeq ($(filter-out kugo suzu dora kagura keyaki,$(TARGET_DEVICE)),)
-LOCAL_SRC_FILES += fpc_imp_loire.c
+LOCAL_SRC_FILES += fpc_imp_loire_tone.c
+endif
+
+ifeq ($(TARGET_FPC_VERSION),N)
+LOCAL_CFLAGS += -DUSE_FPC_N
 endif
 
 LOCAL_CFLAGS += -std=c99

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -17,7 +17,14 @@
 #include "QSEEComAPI.h"
 #include "QSEEComFunc.h"
 #include "fpc_imp.h"
+
+#ifdef USE_FPC_N
+#include "tz_api_tone.h"
+#else
 #include "tz_api_loire.h"
+#endif
+#include "tz_api_loire_tone.h"
+
 #include "common.h"
 
 #include <string.h>
@@ -117,7 +124,7 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
     struct QSEECom_handle *handle = ldata->fpc_handle;
 
     fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) handle->ion_sbuffer;
-    void *rec_cmd = handle->ion_sbuffer + 64;
+    void *rec_cmd = handle->ion_sbuffer + TZ_RESPONSE_OFFSET;
     struct QSEECom_ion_fd_info  ion_fd_info;
 
     memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));

--- a/tz_api_loire_tone.h
+++ b/tz_api_loire_tone.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _TZAPI_LOIRE_TONE_H_
+#define _TZAPI_LOIRE_TONE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FP_TZAPP_PATH "/vendor/firmware/"
+#define FP_TZAPP_NAME "tzfingerprint"
+
+#define KM_TZAPP_PATH "/firmware/image/"
+#define KM_TZAPP_NAME "keymaste"
+#define KM_TZAPP_ALT_NAME "keymaster"
+
+#define BUFFER_SIZE 64
+#define FINGERPRINT_MAX_COUNT 5
+#define AUTH_RESULT_LENGTH 69
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t ret_val; //Some cases this is used for return value of the command
+} fpc_send_std_cmd_t;
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t ret_val; //Some cases this is used for return value of the command
+    uint32_t length; //Some length of data supplied by previous modified command
+} keymaster_cmd_t;
+
+
+typedef struct {
+  int32_t status;
+  uint32_t offset;
+  uint32_t length;
+} keymaster_return_t;
+
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint64_t challenge;
+    int32_t status;
+} fpc_send_auth_cmd_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t gid;
+    int32_t status;
+} fpc_set_gid_t;
+
+typedef struct {
+  uint32_t group_id;
+  uint32_t cmd_id;
+  int32_t status;
+  uint32_t length;
+  char data[];
+} fpc_send_keydata_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint64_t challenge;
+    int32_t status;
+} fpc_load_auth_challenge_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    int32_t status;
+    uint32_t remaining_touches;
+} fpc_enrol_step_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t print_id;
+    int32_t status;
+} fpc_end_enrol_t;
+
+typedef struct {
+  uint32_t group_id;
+  uint32_t cmd_id;
+  int32_t status;
+  uint32_t length;
+  char* data;
+} fpc_send_buffer_t;
+
+typedef struct {
+  uint32_t commandgroup;
+  uint32_t command;
+  int32_t status;
+  uint32_t id;
+  uint32_t dbg1;
+  uint32_t dbg2;
+} fpc_send_identify_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    int32_t status;
+    uint32_t length;
+    uint32_t fingerprints[FINGERPRINT_MAX_COUNT];
+} fpc_fingerprint_list_t;
+
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t fingerprint_id;
+    int32_t status;
+} fpc_fingerprint_delete_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t result;
+    uint32_t length;
+    uint8_t auth_result[AUTH_RESULT_LENGTH]; // In practice this is always 69 bytes
+} fpc_get_auth_result_t;
+
+typedef struct {
+    uint32_t length; //Length of data on ion buffer
+    uint32_t v_addr; //Virtual address of ion mmap buffer
+} fpc_send_mod_cmd_t;
+
+typedef struct {
+    uint32_t group_id;
+    uint32_t cmd_id;
+    uint32_t result;
+    uint32_t auth_id;
+} fpc_get_db_id_cmd_t;
+
+
+#endif /* __TZAPI_LOIRE_TONE_H_ */

--- a/tz_api_tone.h
+++ b/tz_api_tone.h
@@ -23,13 +23,23 @@
 extern "C" {
 #endif
 
-#define TZ_RESPONSE_OFFSET 64
+#define FP_TZAPP_PATH "/vendor/firmware/"
+#define FP_TZAPP_NAME "tzfingerprint"
+
+#define KM_TZAPP_PATH "/firmware/image/"
+#define KM_TZAPP_NAME "keymaste"
+#define KM_TZAPP_ALT_NAME "keymaster"
+
+#define BUFFER_SIZE 64
+
+#define TZ_RESPONSE_OFFSET 256
 
 enum fingerprint_group_t {
   FPC_GROUP_NORMAL = 0x1,
   FPC_GROUP_DB = 0x2,
   FPC_GROUP_FPCDATA = 0x3,
   FPC_GROUP_DEBUG = 0x6, // I think?
+  FPC_GROUP_QC = 0x07,
 };
 
 //enumerate tz app command ID's
@@ -38,17 +48,17 @@ enum fingerprint_normal_cmd_t {
     FPC_ENROL_STEP = 0x01,
     FPC_END_ENROL = 0x02,
     FPC_IDENTIFY = 0x03,
-    FPC_WAIT_FINGER_LOST = 0x04,
-    FPC_WAIT_FINGER_DOWN = 0x06,
-    FPC_GET_FINGER_STATUS =0x07,
-    FPC_LOAD_EMPTY_DB = 0x09,
-    FPC_GET_FINGERPRINTS = 0x0C,
-    FPC_DELETE_FINGERPRINT = 0x0D,
-    FPC_CAPTURE_IMAGE = 0x0E,
-    FPC_SET_GID = 0x0F,
-    FPC_GET_TEMPLATE_ID = 0x10,
-    FPC_INIT = 0x11,
-    FPC_PRINT_INFO = 0x12,
+    FPC_UPDATE_TEMPLATE = 0x04,
+    FPC_WAIT_FINGER_LOST = 0x05,
+    FPC_WAIT_FINGER_DOWN = 0x07,
+    FPC_GET_FINGER_STATUS =0x8,
+    FPC_LOAD_EMPTY_DB = 0x0A,
+    FPC_GET_FINGERPRINTS = 0xD,
+    FPC_DELETE_FINGERPRINT = 0xE,
+    FPC_CAPTURE_IMAGE = 0xF,
+    FPC_SET_GID = 0x10,
+    FPC_GET_TEMPLATE_ID = 0x11,
+    FPC_INIT = 0x12,
 };
 
 enum fingerprint_fpcdata_cmd_t {
@@ -56,18 +66,23 @@ enum fingerprint_fpcdata_cmd_t {
     FPC_GET_AUTH_CHALLENGE = 0x02,
     FPC_AUTHORIZE_ENROL = 0x03,
     FPC_GET_AUTH_RESULT = 0x04,
-    FPC_SET_KEY_DATA= 0x05,
+    FPC_SET_KEY_DATA = 0x05,
+    FPC_IS_USER_VALID = 0x07,
 };
 
 enum fingerprint_db_cmd_t {
-    FPC_LOAD_DB = 0x0A,
-    FPC_STORE_DB = 0x0B,
+    FPC_LOAD_DB = 0x0B,
+    FPC_STORE_DB = 0x0C,
 };
 
 enum fingerprint_debug_cmd_t {
-   FPC_GET_SENSOR_INFO = 0x03,
+    FPC_GET_SENSOR_INFO = 0x03,
 };
 
+enum fingerprint_qc_cmd_t {
+    FPC_SET_QC_AUTH_NONCE = 0x01,
+    FPC_GET_QC_AUTH_RESULT = 0x02,
+};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Enable by putting the following in BoardConfig or PlatformConfig

TARGET_FPC_VERSION := N

Beware that prints in any existing template db won't work anymore! They need to be deleted and re-added.