### PR TITLE
improve fingerprint

### DIFF
--- a/fingerprint.c
+++ b/fingerprint.c
@@ -304,6 +304,7 @@ static int fingerprint_cancel(struct fingerprint_device *dev)
 {
     ALOGI("%s : +",__func__);
     sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    fingerprint_notify_t callback = sdev->device.notify;
     
     ALOGI("%s : check thread running",__func__);
     pthread_mutex_lock(&sdev->lock);
@@ -320,10 +321,10 @@ static int fingerprint_cancel(struct fingerprint_device *dev)
 
     ALOGI("%s : -",__func__);
 
-    /*fingerprint_msg_t msg;
+    fingerprint_msg_t msg;
     msg.type = FINGERPRINT_ERROR;
     msg.data.error = FINGERPRINT_ERROR_CANCELED;
-    callback(&msg);*/
+    callback(&msg);
 
     return 0;
 }

--- a/fingerprint.c
+++ b/fingerprint.c
@@ -210,6 +210,10 @@ void *auth_thread_loop(void *arg)
                     break;
                 }
             }
+            fingerprint_msg_t msg;
+            msg.type = FINGERPRINT_AUTHENTICATED;
+            msg.data.authenticated.finger.fid = 0;
+            callback(&msg);
         }
     }
 

--- a/fingerprint.c
+++ b/fingerprint.c
@@ -460,9 +460,6 @@ static int fingerprint_authenticate(struct fingerprint_device __attribute__((unu
     sdev->worker.thread_running = true;
     pthread_mutex_unlock(&sdev->lock);
 
-    // FIXME: Verify whether this needs to run on each
-    fpc_set_auth_challenge(sdev->fpc, 0);
-
     if(pthread_create(&sdev->worker.thread, NULL, auth_thread_loop, (void*)sdev)) {
         sdev->worker.thread_running = false;
         ALOGE("%s : Error creating thread\n", __func__);

--- a/fingerprint.c
+++ b/fingerprint.c
@@ -461,6 +461,9 @@ static int fingerprint_authenticate(struct fingerprint_device __attribute__((unu
     sdev->worker.thread_running = true;
     pthread_mutex_unlock(&sdev->lock);
 
+    // FIXME: Verify whether this needs to run on each
+    fpc_set_auth_challenge(sdev->fpc, 0);
+
     if(pthread_create(&sdev->worker.thread, NULL, auth_thread_loop, (void*)sdev)) {
         sdev->worker.thread_running = false;
         ALOGE("%s : Error creating thread\n", __func__);


### PR DESCRIPTION
1. Add authentication failed message, enable vibration feedback for wrong finger, improve security because if there are too many wrong attempts fingerprint will be disabled.
2. Remove redundancy of changing thread_running var, and move the mutex code before logging.
3. Remove unneeded function.
4. Enable cancel message, fix crashed fingerprint setting and random reboot.