### PR TITLE
fingerprint: move to vendor only from Oreo

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -61,8 +61,10 @@ endif
 LOCAL_CFLAGS += -DPLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION)
 
 LOCAL_MODULE_TAGS := optional
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 25 ))" )))
 LOCAL_MODULE_OWNER := sony
 LOCAL_PROPRIETARY_MODULE := true
+endif
 
 include $(BUILD_SHARED_LIBRARY)
 endif


### PR DESCRIPTION
same branch is used by N and O
we want to be sure the HAL is moved to vendor only for Oreo

Signed-off-by: David Viteri <davidteri91@gmail.com>