### PR TITLE
yoshino: tone: loire: locally cache the value of auth_id

### DIFF
--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -299,6 +299,10 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
     ALOGD(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
+    // return cached auth_id value if available
+    if(ldata->auth_id) {
+        return ldata->auth_id;
+    }
     fpc_get_db_id_cmd_t cmd = {0};
     cmd.group_id = FPC_GROUP_NORMAL;
     cmd.cmd_id = FPC_GET_TEMPLATE_ID;
@@ -307,6 +311,8 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
         ALOGE("Error sending data to TZ\n");
         return -1;
     }
+    // cache the auth_id value received from TZ
+    ldata->auth_id = cmd.auth_id;
     return cmd.auth_id;
 }
 
@@ -364,6 +370,8 @@ err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id)
         ALOGE("Error sending command: %d\n", ret);
         return -1;
     }
+    // remove the cached auth_id value upon deleting a fingerprint
+    ldata->auth_id = 0;
     return cmd.status;
 }
 
@@ -502,6 +510,8 @@ err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id)
     }
 
     *print_id = cmd.print_id;
+    // remove the cached auth_id value upon enrolling a fingerprint
+    ldata->auth_id = 0;
     return 0;
 }
 

--- a/fpc_imp_yoshino.c
+++ b/fpc_imp_yoshino.c
@@ -294,6 +294,10 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
     ALOGD(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
+    // return cached auth_id value if available
+    if(ldata->auth_id) {
+        return ldata->auth_id;
+    }
     fpc_get_db_id_cmd_t cmd = {0};
     cmd.group_id = FPC_GROUP_TEMPLATE;
     cmd.cmd_id = FPC_GET_TEMPLATE_ID;
@@ -302,6 +306,8 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
         ALOGE("Error sending data to TZ\n");
         return -1;
     }
+    // cache the auth_id value received from TZ
+    ldata->auth_id = cmd.auth_id;
     return cmd.auth_id;
 }
 
@@ -359,6 +365,8 @@ err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id)
         ALOGE("Error sending command: %d\n", ret);
         return -1;
     }
+    // remove the cached auth_id value upon deleting a fingerprint
+    ldata->auth_id = 0;
     return cmd.status;
 }
 
@@ -497,6 +505,8 @@ err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id)
     }
 
     *print_id = cmd.print_id;
+    // remove the cached auth_id value upon enrolling a fingerprint
+    ldata->auth_id = 0;
     return 0;
 }
 


### PR DESCRIPTION
The cmd used to receive auth_id from TZ in fpc_load_db_id can cause device crashes under certain unclear circumstances.
The auth_id value remains the same, unless one of the following happens:
1. A new fingerprint is enrolled
2. All enrolled fingerprints are deleted
So in order to reduce the number of times the cmd is sent, cache the value returned by fpc_load_db_id once the call is made.
For subsequent calls, simply rely on the cached value.
In case an enrollment happens, or a fingerprint is deleted, remove the cached value in order for the next call to repopulate the cache.
This should be sufficient to fix the random rebooting happening on yoshino, loire and tone devices.

Change-Id: I7815eafb0ef69b82dafe3581a7b103ec79aeb473