### PR TITLE
[FINGERPRINT] common: Use new power and IRQ IOCTLs for FPC device driver

### DIFF
--- a/common.c
+++ b/common.c
@@ -54,6 +54,35 @@ err_t fpc_get_power(void)
     return reply;
 }
 
+err_t fpc_poll_irq(void)
+{
+    int fd, ret = -1;
+    uint32_t arg = 0;
+    struct pollfd pfd;
+
+    fd = open("/dev/fingerprint", O_RDWR | O_NONBLOCK);
+    if (fd < 0) {
+        ALOGE("Error opening FPC device\n");
+        return -1;
+    }
+
+    ret = ioctl(fd, FPC_IOCRIRQPOLL, &arg);
+    if (ret < 0) {
+        ALOGE("Error polling FPC device\n");
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    ALOGD("Interrupt status: %d\n", arg);
+
+    /* 0 means that the interrupt didn't fire */
+    if (arg == 0)
+        return -1;
+
+    return (err_t)arg;
+}
+
 err_t sysfs_write(char *path, char *s)
 {
     char buf[80];

--- a/common.c
+++ b/common.c
@@ -8,6 +8,51 @@
 #define LOG_TAG "FPC COMMON"
 
 #include <cutils/log.h>
+#include <sys/ioctl.h>
+
+err_t fpc_set_power(int poweron)
+{
+    int fd, ret = -1;
+
+    fd = open("/dev/fingerprint", O_RDWR);
+    if (fd < 0) {
+        ALOGE("Error opening FPC device\n");
+        return -1;
+    }
+    ret = ioctl(fd, FPC_IOCWPREPARE, poweron);
+    if (ret < 0) {
+        ALOGE("Error preparing FPC device\n");
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    return 1;
+}
+
+err_t fpc_get_power(void)
+{
+    int fd, ret = -1;
+    uint32_t reply = -1;
+
+    fd = open("/dev/fingerprint", O_RDWR);
+    if (fd < 0) {
+        ALOGE("Error opening FPC device\n");
+        return -1;
+    }
+    ret = ioctl(fd, FPC_IOCRPREPARE, &reply);
+    if (ret < 0) {
+        ALOGE("Error preparing FPC device\n");
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    if (reply > 1)
+        return -1;
+
+    return reply;
+}
 
 err_t sysfs_write(char *path, char *s)
 {

--- a/common.h
+++ b/common.h
@@ -3,7 +3,22 @@
 
 #include <stdint.h>
 
+#define FPC_IOC_MAGIC	0x1145
+#define FPC_IOCWPREPARE	_IOW(FPC_IOC_MAGIC, 0x01, int)
+#define FPC_IOCWDEVWAKE _IOW(FPC_IOC_MAGIC, 0x02, int)
+#define FPC_IOCWRESET	_IOW(FPC_IOC_MAGIC, 0x03, int)
+#define FPC_IOCRPREPARE _IOR(FPC_IOC_MAGIC, 0x81, int)
+#define FPC_IOCRDEVWAKE _IOR(FPC_IOC_MAGIC, 0x82, int)
+#define FPC_IOCRIRQ	_IOR(FPC_IOC_MAGIC, 0x83, int)
+
+enum {
+    FPC_PWROFF = 0,
+    FPC_PWRON = 1,
+};
+
 typedef int32_t err_t;
+err_t fpc_set_power(int poweron);
+err_t fpc_get_power(void);
 err_t sysfs_write(char *path, char *s);
 err_t sys_fs_irq_poll(char *path);
 

--- a/common.h
+++ b/common.h
@@ -10,6 +10,7 @@
 #define FPC_IOCRPREPARE _IOR(FPC_IOC_MAGIC, 0x81, int)
 #define FPC_IOCRDEVWAKE _IOR(FPC_IOC_MAGIC, 0x82, int)
 #define FPC_IOCRIRQ	_IOR(FPC_IOC_MAGIC, 0x83, int)
+#define FPC_IOCRIRQPOLL	_IOR(FPC_IOC_MAGIC, 0x84, int)
 
 enum {
     FPC_PWROFF = 0,
@@ -19,6 +20,7 @@ enum {
 typedef int32_t err_t;
 err_t fpc_set_power(int poweron);
 err_t fpc_get_power(void);
+err_t fpc_poll_irq(void);
 err_t sysfs_write(char *path, char *s);
 err_t sys_fs_irq_poll(char *path);
 

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -38,10 +38,6 @@
 #include <cutils/log.h>
 #include <limits.h>
 
-#define SPI_CLK_FILE  "/sys/bus/spi/devices/spi0.1/clk_enable"
-#define SPI_WAKE_FILE SYSFS_PREFIX "/wakeup_enable"
-#define SPI_IRQ_FILE  SYSFS_PREFIX "/irq"
-
 typedef struct {
     struct fpc_imp_data_t data;
     struct QSEECom_handle *fpc_handle;
@@ -49,18 +45,6 @@ typedef struct {
     struct qcom_km_ion_info_t ihandle;
     uint32_t auth_id;
 } fpc_data_t;
-
-static err_t poll_irq(char *path)
-{
-    err_t ret = 0;
-    sysfs_write(SPI_WAKE_FILE, "disable");
-    sysfs_write(SPI_WAKE_FILE, "enable");
-
-    ret = sys_fs_irq_poll(path);
-
-    sysfs_write(SPI_WAKE_FILE, "disable");
-    return ret;
-}
 
 static const char *fpc_error_str(int err)
 {
@@ -366,7 +350,7 @@ err_t fpc_wait_finger_down(fpc_imp_data_t *data)
         if(result)
             return result;
 
-        if((result = poll_irq(SPI_IRQ_FILE)) == -1) {
+        if((result = fpc_poll_irq()) == -1) {
                 ALOGE("Error waiting for irq: %d\n", result);
                 return -1;
         }

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -39,7 +39,6 @@
 #include <limits.h>
 
 #define SPI_CLK_FILE  "/sys/bus/spi/devices/spi0.1/clk_enable"
-#define SPI_PREP_FILE SYSFS_PREFIX "/spi_prepare"
 #define SPI_WAKE_FILE SYSFS_PREFIX "/wakeup_enable"
 #define SPI_IRQ_FILE  SYSFS_PREFIX "/irq"
 
@@ -60,31 +59,6 @@ static err_t poll_irq(char *path)
 
     sysfs_write(SPI_WAKE_FILE, "disable");
     return ret;
-}
-
-
-err_t device_enable()
-{
-    if (sysfs_write(SPI_PREP_FILE,"enable")< 0) {
-        return -1;
-    }
-
-/*    if (sysfs_write(SPI_CLK_FILE,"1")< 0) {
-        return -1;
-    }*/
-    return 1;
-}
-
-err_t device_disable()
-{
-/*    if (sysfs_write(SPI_CLK_FILE,"0")< 0) {
-        return -1;
-    }*/
-
-    if (sysfs_write(SPI_PREP_FILE,"disable")< 0) {
-        return -1;
-    }
-    return 1;
 }
 
 static const char *fpc_error_str(int err)
@@ -427,7 +401,7 @@ err_t fpc_capture_image(fpc_imp_data_t *data)
 
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    if (device_enable() < 0) {
+    if (fpc_set_power(FPC_PWRON) < 0) {
         ALOGE("Error starting device\n");
         return -1;
     }
@@ -448,7 +422,7 @@ err_t fpc_capture_image(fpc_imp_data_t *data)
         ret = 1000;
     }
 
-    if (device_disable() < 0) {
+    if (fpc_set_power(FPC_PWROFF) < 0) {
         ALOGE("Error stopping device\n");
         return -1;
     }
@@ -656,7 +630,7 @@ err_t fpc_close(fpc_imp_data_t **data)
     ALOGD(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
     ldata->qsee_handle->shutdown_app(&ldata->fpc_handle);
-    if (device_disable() < 0) {
+    if (fpc_set_power(FPC_PWROFF) < 0) {
         ALOGE("Error stopping device\n");
         return -1;
     }
@@ -680,7 +654,7 @@ err_t fpc_init(fpc_imp_data_t **data)
         goto err;
     }
 
-    if (device_enable() < 0) {
+    if (fpc_set_power(FPC_PWRON) < 0) {
         ALOGE("Error starting device\n");
         goto err_qsee;
     }
@@ -745,7 +719,7 @@ err_t fpc_init(fpc_imp_data_t **data)
     if(result != 0)
         return result;
 
-    if (device_disable() < 0) {
+    if (fpc_set_power(FPC_PWROFF) < 0) {
         ALOGE("Error stopping device\n");
         goto err_alloc;
     }

--- a/fpc_imp_yoshino.c
+++ b/fpc_imp_yoshino.c
@@ -34,10 +34,6 @@
 #include <cutils/log.h>
 #include <limits.h>
 
-#define SPI_CLK_FILE  "/sys/bus/spi/devices/spi0.1/clk_enable"
-#define SPI_WAKE_FILE SYSFS_PREFIX "/wakeup_enable"
-#define SPI_IRQ_FILE  SYSFS_PREFIX "/irq"
-
 typedef struct {
     struct fpc_imp_data_t data;
     struct QSEECom_handle *fpc_handle;
@@ -45,18 +41,6 @@ typedef struct {
     struct qcom_km_ion_info_t ihandle;
     uint32_t auth_id;
 } fpc_data_t;
-
-static err_t poll_irq(char *path)
-{
-    err_t ret = 0;
-    sysfs_write(SPI_WAKE_FILE, "disable");
-    sysfs_write(SPI_WAKE_FILE, "enable");
-
-    ret = sys_fs_irq_poll(path);
-
-    sysfs_write(SPI_WAKE_FILE, "disable");
-    return ret;
-}
 
 static const char *fpc_error_str(int err)
 {
@@ -362,7 +346,7 @@ err_t fpc_wait_finger_down(fpc_imp_data_t *data)
         if(result)
             return result;
 
-        if((result = poll_irq(SPI_IRQ_FILE)) == -1) {
+        if((result = fpc_poll_irq()) == -1) {
                 ALOGE("Error waiting for irq: %d\n", result);
                 return -1;
         }

--- a/fpc_imp_yoshino.c
+++ b/fpc_imp_yoshino.c
@@ -42,6 +42,7 @@ typedef struct {
     struct fpc_imp_data_t data;
     struct QSEECom_handle *fpc_handle;
     struct qsee_handle_t* qsee_handle;
+    struct qcom_km_ion_info_t ihandle;
     uint32_t auth_id;
 } fpc_data_t;
 
@@ -124,30 +125,19 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
 
 err_t send_normal_command(fpc_data_t *ldata, int group, int command)
 {
-    struct qcom_km_ion_info_t ihandle;
-
-
-    ihandle.ion_fd = 0;
-
-    if (ldata->qsee_handle->ion_alloc(&ihandle, 0x40) <0) {
-        ALOGE("ION allocation  failed");
-        return -1;
-    }
-
-    // TODO: use single shared buffer instead of allocating/free'ing again and again
-    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) ihandle.ion_sbuffer;
+    fpc_send_std_cmd_t* send_cmd =
+        (fpc_send_std_cmd_t*) ldata->ihandle.ion_sbuffer;
 
     send_cmd->group_id = group;
     send_cmd->cmd_id = command;
     send_cmd->ret_val = 0x0;
 
-    int ret = send_modified_command_to_tz(ldata, ihandle);
+    int ret = send_modified_command_to_tz(ldata, ldata->ihandle);
 
     if(!ret) {
         ret = send_cmd->ret_val;
     }
 
-    ldata->qsee_handle->ion_free(&ihandle);
     return ret;
 }
 
@@ -748,6 +738,12 @@ err_t fpc_init(fpc_imp_data_t **data)
     qsee_handle->shutdown_app(&mKeymasterHandle);
     mKeymasterHandle = NULL;
 
+    fpc_data->ihandle.ion_fd = 0;
+    if (fpc_data->qsee_handle->ion_alloc(&fpc_data->ihandle, 0x40) < 0) {
+        ALOGE("ION allocation failed");
+        goto err_keymaster;
+    }
+
     int result = send_buffer_command(fpc_data, FPC_GROUP_FPCDATA, FPC_SET_KEY_DATA, keydata, keylength);
 
     ALOGD("FPC_SET_KEY_DATA Result: %d\n", result);
@@ -769,8 +765,10 @@ err_keymaster:
     if(mKeymasterHandle != NULL)
         qsee_handle->shutdown_app(&mKeymasterHandle);
 err_alloc:
-    if(fpc_data != NULL)
+    if(fpc_data != NULL) {
+        fpc_data->qsee_handle->ion_free(&fpc_data->ihandle);
         free(fpc_data);
+    }
 err_qsee:
     qsee_free_handle(&qsee_handle);
 err:


### PR DESCRIPTION
The kernel driver now features a miscdevice and IOCTLs.
Add definitions for all of the IOCTLs and convert the
device power management to use them.

This also unifies the power on/off functions between the
implementations.

------------------------------------------------------------------------------
This patchset is not yet complete.
Need to finish the implementation with the IRQ IOCTL, plus a
bugfix for the Yoshino platform crash which is currently under
testing and not yet published.

This PR is there as a partial showdown of what will happen in
the near future, to make other users able to eventually help
testing the new IOCTL implementation in the kernel driver.

This code will only work with this kernel related PR:
https://github.com/sonyxperiadev/kernel/pull/1518

Please note that this commit may change, as it may be better
to actually pull an IOCTL definition header from the kernel itself.