### PR TITLE
fingerprint: add back callback to fingerprint_cancel

### DIFF
--- a/fingerprint.c
+++ b/fingerprint.c
@@ -295,6 +295,7 @@ static int fingerprint_cancel(struct fingerprint_device *dev)
 {
     ALOGI("%s : +",__func__);
     sony_fingerprint_device_t *sdev = (sony_fingerprint_device_t*)dev;
+    fingerprint_notify_t callback = sdev->device.notify;
 
     pthread_mutex_lock(&sdev->lock);
     bool thread_running = sdev->worker.thread_running ;
@@ -315,10 +316,10 @@ static int fingerprint_cancel(struct fingerprint_device *dev)
 
     ALOGI("%s : -",__func__);
 
-    /*fingerprint_msg_t msg;
+    fingerprint_msg_t msg;
     msg.type = FINGERPRINT_ERROR;
     msg.data.error = FINGERPRINT_ERROR_CANCELED;
-    callback(&msg);*/
+    callback(&msg);
 
     return 0;
 }


### PR DESCRIPTION
the callback is needed by android, because otherwise, FingerprintService will wait on it, then timeout after 3 seconds and start authentication again.
With the callback, the service starts authentication immediately after calling fingerprint_cancel.

Change-Id: If0b55dcf8e55fe111bb4d03ac87d2ac002bfd5b1