### PR TITLE
[FINGERPRINT] BiometricsFingerprint: Crash and restart on fatal TZ error

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -598,6 +598,11 @@ void * BiometricsFingerprint::worker_thread(void *args){
                         ALOGI("%s : Got print id : %u", __func__, print_id);
                         thisPtr->mClientCallback->onAuthenticated(devId, fid, gid, hidl_vec<uint8_t>());
                     }
+                } else {
+                    setState(sdev, STATE_IDLE);
+                    thisPtr->mClientCallback->onError(devId, FingerprintError::ERROR_CANCELED, 0);
+                    raise(SIGKILL);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
When a fatal TZ error happens, the only way to get FPC
back working is to completely reinitialize everything.
Send ERROR_CANCELED to notify that the auth stage has
been canceled and then raise a SIGKILL to produce this
behavior.


Tested on SoMC Maple