### PR TITLE
Use SOMC_PLATFORM to guard platform specific sources

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -12,20 +12,20 @@ LOCAL_SRC_FILES := \
     QSEEComFunc.c \
     common.c
 
-ifeq ($(filter-out kitakami,$(TARGET_BOOTLOADER_BOARD_NAME)),)
+ifeq ($(filter-out kitakami,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_kitakami.c
 LOCAL_CFLAGS += -DFPC_DB_PER_GID
 endif
 
-ifeq ($(filter-out loire tone,$(TARGET_BOOTLOADER_BOARD_NAME)),)
+ifeq ($(filter-out loire tone,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_loire_tone.c
 endif
 
-ifeq ($(filter-out yoshino,$(TARGET_BOOTLOADER_BOARD_NAME)),)
+ifeq ($(filter-out yoshino,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile.c
 endif
 
-ifeq ($(filter-out nile,$(TARGET_BOOTLOADER_BOARD_NAME)),)
+ifeq ($(filter-out nile,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile.c
 LOCAL_CFLAGS += -DUSE_FPC_NILE
 endif


### PR DESCRIPTION
TARGET_BOOTLOADER_BOARD_NAME is an aosp build system variable that is
typically used to store a device-specific boardname (e.g. bullhead,
marlin, sailfish), but it was utilized in the sony device projects to
store the platform name instead (e.g. yoshino).  Unfortunately, that
causes updatepackage zips to break, so it seems better to use the sony
variable SOMC_PLATFORM here instead.