### PR TITLE
Pie fixes

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -583,7 +583,7 @@ void * BiometricsFingerprint::worker_thread(void *args){
                         ALOGI("%s : hat->user_id %ju", __func__, hat.user_id);
                         ALOGI("%s : hat->authenticator_id %ju",  __func__, hat.authenticator_id);
                         ALOGI("%s : hat->authenticator_type %u", __func__, ntohl(hat.authenticator_type));
-                        ALOGI("%s : hat->timestamp %ju", __func__, bswap_64(hat.timestamp));
+                        ALOGI("%s : hat->timestamp %llu", __func__, bswap_64(hat.timestamp));
                         ALOGI("%s : hat size %zu", __func__, sizeof(hw_auth_token_t));
 
                         fid = print_id;

--- a/QSEEComFunc.c
+++ b/QSEEComFunc.c
@@ -210,7 +210,6 @@ int32_t qcom_km_ion_memalloc(struct qcom_km_ion_info_t *handle,
 {
     int32_t ret = 0;
     int32_t iret = 0;
-    int32_t fd = 0;
     unsigned char *v_addr;
     struct ion_allocation_data ion_alloc_data;
     int32_t ion_fd;

--- a/common.c
+++ b/common.c
@@ -58,7 +58,6 @@ err_t fpc_poll_irq(void)
 {
     int fd, ret = -1;
     uint32_t arg = 0;
-    struct pollfd pfd;
 
     fd = open("/dev/fingerprint", O_RDWR | O_NONBLOCK);
     if (fd < 0) {

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -340,7 +340,6 @@ err_t fpc_wait_finger_down(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     int result=-1;
-    int i;
     fpc_data_t *ldata = (fpc_data_t*)data;
 
 //    while(1)
@@ -496,7 +495,7 @@ err_t fpc_auth_end(fpc_imp_data_t __unused *data)
     return 0;
 }
 
-err_t fpc_update_template(fpc_imp_data_t *data)
+err_t fpc_update_template(fpc_imp_data_t __unused *data)
 {
     // TODO: Implement for loire/tone
     return 0;
@@ -560,7 +559,6 @@ err_t fpc_load_empty_db(fpc_imp_data_t *data) {
 err_t fpc_load_user_db(fpc_imp_data_t *data, char* path)
 {
     int result;
-    struct stat sb;
     fpc_data_t *ldata = (fpc_data_t*)data;
 
     ALOGD("Loading user db from %s\n", path);

--- a/fpc_imp_yoshino_nile.c
+++ b/fpc_imp_yoshino_nile.c
@@ -71,7 +71,7 @@ static const char *error_strings[] = {
     "FPC_ERROR_INPUT",
 };
 
-static const uint32_t num_error_strings = sizeof(error_strings) / sizeof(error_strings[0]);
+static const int num_error_strings = sizeof(error_strings) / sizeof(error_strings[0]);
 
 static const char *fpc_error_str(int err)
 {

--- a/service.cpp
+++ b/service.cpp
@@ -23,11 +23,14 @@
 #include <android/hardware/biometrics/fingerprint/2.1/types.h>
 #include "BiometricsFingerprint.h"
 
-using android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
-using android::hardware::biometrics::fingerprint::V2_1::implementation::BiometricsFingerprint;
+using namespace android;
+
+using android::sp;
 using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
-using android::sp;
+using android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
+using android::hardware::biometrics::fingerprint::V2_1::implementation::
+    BiometricsFingerprint;
 
 int main() {
     android::sp<IBiometricsFingerprint> bio = BiometricsFingerprint::getInstance();
@@ -35,9 +38,14 @@ int main() {
     configureRpcThreadpool(1, true /*callerWillJoin*/);
 
     if (bio != nullptr) {
-        bio->registerAsService();
+        status_t status = bio->registerAsService();
+        if (status != NO_ERROR) {
+            ALOGE("Cannot start fingerprint service: %d", status);
+            return 1;
+        }
     } else {
         ALOGE("Can't create instance of BiometricsFingerprint, nullptr");
+        return 1;
     }
 
     joinRpcThreadpool();


### PR DESCRIPTION
~~Upgraded C++ version to 14 to be able to use `enable_if_t` (in a header from hidl).~~

Also silenced most warnings while at it.

Left `vendor/oss/fingerprint/fpc_imp.h:31:9: warning: empty struct has size 0 in C, size 1 in C++ [-Wextern-c-compat]` for a future revision.

Build-tested with `mm android.hardware.biometrics.fingerprint@2.1-service.sony`