### PR TITLE
loire/tone: Fix auth_id size and location.

### DIFF
--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -42,7 +42,7 @@ typedef struct {
     struct QSEECom_handle *fpc_handle;
     struct qsee_handle_t* qsee_handle;
     struct qcom_km_ion_info_t ihandle;
-    uint32_t auth_id;
+    uint64_t auth_id;
 } fpc_data_t;
 
 static const char *fpc_error_str(int err)

--- a/fpc_imp_yoshino_nile.c
+++ b/fpc_imp_yoshino_nile.c
@@ -47,7 +47,7 @@ typedef struct {
     struct QSEECom_handle *fpc_handle;
     struct qsee_handle_t* qsee_handle;
     struct qcom_km_ion_info_t ihandle;
-    uint32_t auth_id;
+    uint64_t auth_id;
 } fpc_data_t;
 
 err_t fpc_deep_sleep(fpc_imp_data_t *data);

--- a/tz_api_loire_tone.h
+++ b/tz_api_loire_tone.h
@@ -195,8 +195,7 @@ typedef struct {
 typedef struct {
     uint32_t group_id;
     uint32_t cmd_id;
-    uint32_t result;
-    uint32_t auth_id;
+    uint64_t auth_id;
 } fpc_get_db_id_cmd_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
The size of auth_id is 64bits, and it's least-significant 32-bits were
stored in the incorrect `result` field.

This change makes auth_id (as returned by getAuthenticatorId) equal to
the value of hat->authenticator_id, allowing applications that use HATs
such as banking apps to work with fingerprint authentication.

TODO: The same should be checked on Yoshino and Nile (with FPC sensors),
and potentially patched in a similar way. It might be spanned over
result and/or unk1 in their fpc_get_db_id_cmd_t struct.