### PR TITLE
Fix enumerate(), called since android Pie

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -187,14 +187,7 @@ Return<RequestStatus> BiometricsFingerprint::enumerate()  {
     ALOGV(__func__);
     sony_fingerprint_device_t *sdev = mDevice;
 
-    uint32_t print_count = fpc_get_print_count(sdev->fpc);
-    ALOGD("%s : print count is : %u", __func__, print_count);
-
-    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(sdev->fpc, print_count);
-    if(print_indexs.print_count != print_count)
-    {
-        ALOGW("Print count mismatch: %d != %d", print_count, print_indexs.print_count);
-    }
+    fpc_fingerprint_index_t print_indexs = fpc_get_print_index(sdev->fpc);
 
     if (!print_indexs.print_count)
         // When there are no fingers, the service still needs to know that (potentially async)
@@ -455,9 +448,9 @@ void * BiometricsFingerprint::worker_thread(void *args){
 }
 
     void BiometricsFingerprint::process_enroll(sony_fingerprint_device_t *sdev) {
-
-        int32_t print_count = fpc_get_print_count(sdev->fpc);
-        ALOGD("%s : print count is : %u", __func__, print_count);
+        // WARNING: Not implemented on any platform
+        int32_t print_count = 0;
+        // ALOGD("%s : print count is : %u", __func__, print_count);
 
         BiometricsFingerprint* thisPtr = static_cast<BiometricsFingerprint*>(
                 BiometricsFingerprint::getInstance());

--- a/fpc_imp.h
+++ b/fpc_imp.h
@@ -41,10 +41,9 @@ err_t fpc_get_hw_auth_obj(fpc_imp_data_t *data, void * buffer, uint32_t length);
 // Make all functions return resolved index->id
 // FIXME: Internal to kitakami:
 err_t fpc_get_print_id(fpc_imp_data_t *data, int id);
-err_t fpc_get_print_count(fpc_imp_data_t *data); //get count of enrolled prints
 err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id); //delete print at index
 fpc_fingerprint_index_t fpc_get_print_ids(fpc_imp_data_t *data, uint32_t count); //get list of print index's available
-fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data, uint32_t count); //get list of print index's available
+fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data); //get list of print index's available
 err_t fpc_wait_for_finger(fpc_imp_data_t *data); //wait for event IRQ on print reader
 err_t fpc_capture_image(fpc_imp_data_t *data); //capture image ready for enroll / auth
 err_t fpc_enroll_step(fpc_imp_data_t *data, uint32_t *remaining_touches); //step forward enroll & process image (only available if capture image returns OK)

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -496,33 +496,27 @@ err_t fpc_update_template(fpc_imp_data_t __unused *data)
     return 0;
 }
 
-
-err_t fpc_get_print_count(fpc_imp_data_t __unused *data)
-{
-    ALOGV(__func__);
-    return 0;
-}
-
-
-fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data, uint32_t __unused count)
+fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_fingerprint_index_t idx_data = {0};
-    fpc_fingerprint_list_t cmd = {0};
+    fpc_fingerprint_list_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_GET_FINGERPRINTS,
+        .length = MAX_FINGERPRINTS,
+    };
     unsigned int i;
-
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_GET_FINGERPRINTS;
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0 || cmd.status != 0)
     {
-        ALOGE("Error retrieving fingerprints\n");
+        ALOGE("Error retrieving fingerprints: rc = %d, status = %d", ret, cmd.status);
     }
 
-    ALOGI("Found %d fingerprints\n", cmd.length);
-    for(i=0; i<cmd.length; i++)
+    ALOGI("Found %d fingerprints", cmd.length);
+    idx_data.print_count = cmd.length;
+    for(i=0; i< cmd.length; i++)
     {
         idx_data.prints[i] = cmd.fingerprints[i];
     }

--- a/fpc_imp_yoshino_nile.c
+++ b/fpc_imp_yoshino_nile.c
@@ -495,32 +495,27 @@ err_t fpc_auth_end(fpc_imp_data_t __unused *data)
 }
 
 
-err_t fpc_get_print_count(fpc_imp_data_t __unused *data)
-{
-    ALOGV(__func__);
-    return 0;
-}
-
-
-fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data, uint32_t __unused count)
+fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
     fpc_fingerprint_index_t idx_data = {0};
-    fpc_fingerprint_list_t cmd = {0};
+    fpc_fingerprint_list_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_GET_FINGERPRINTS,
+        .length = MAX_FINGERPRINTS,
+    };
     unsigned int i;
-
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_GET_FINGERPRINTS;
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0 || cmd.status != 0)
     {
-        ALOGE("Error retrieving fingerprints\n");
+        ALOGE("Error retrieving fingerprints: rc = %d, status = %d", ret, cmd.status);
     }
 
-    ALOGI("Found %d fingerprints\n", cmd.length);
-    for(i=0; i<cmd.length; i++)
+    ALOGI("Found %d fingerprints", cmd.length);
+    idx_data.print_count = cmd.length;
+    for(i=0; i< cmd.length; i++)
     {
         idx_data.prints[i] = cmd.fingerprints[i];
     }


### PR DESCRIPTION
Merge #38 first.

Android Pie enumerates fingerprints to do cleanups and make sure the db stays in sync. It "works" in it's current form because the service times out waiting for fingerprints to be reported. 
These patches fix the calls to retrieve fingerprints from the database and report them to the service. It also handles the special case where no fingers are enrolled (the service still needs to be notified of that).