### PR TITLE
Change sp<> unary conversion to null-check for android 8.

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -179,7 +179,7 @@ Return<RequestStatus> BiometricsFingerprint::cancel() {
 Return<RequestStatus> BiometricsFingerprint::enumerate()  {
 
     const uint64_t devId = reinterpret_cast<uint64_t>(mDevice);
-    if (!mClientCallback) {
+    if (mClientCallback == nullptr) {
         ALOGE("Client callback not set");
         return RequestStatus::SYS_EFAULT;
     }


### PR DESCRIPTION
This unary boolean check was added in android 9 while the HAL is also
being used on android 8. Put the original check back to stay compatible.

Build-tested on Android 8.1 and Android 9.