### PR TITLE
BiometricsFingerprint: retry authentication for recoverable errors

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -594,6 +594,9 @@ void * BiometricsFingerprint::worker_thread(void *args){
                         ALOGI("%s : Got print id : %u", __func__, print_id);
                         thisPtr->mClientCallback->onAuthenticated(devId, fid, gid, hidl_vec<uint8_t>());
                     }
+                } else if (verify_state == -EAGAIN) {
+                    ALOGI("%s : retrying due to receiving -EAGAIN", __func__);
+                    thisPtr->mClientCallback->onAuthenticated(devId, fid, gid, hidl_vec<uint8_t>());
                 } else {
                     int grp_err = -1;
                     /*


### PR DESCRIPTION
Currently, when authentication fails for any reason, a complete restart of the hal is done.
This is not necessary for when the error is recoverable.
In such cases, simply retry and report to the client that the authentication failed.

Change-Id: I8800c72c998fe979a60472b2f74d9bdc70a765f9