### PR TITLE
Egistec: Declare undefined static constexpr variables as inline

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -48,7 +48,8 @@ endif
 
 LOCAL_CFLAGS += \
     -DPLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION) \
-    -fexceptions
+    -fexceptions \
+    -std=c++1z
 
 include $(BUILD_EXECUTABLE)
 endif

--- a/EGISAPTrustlet.h
+++ b/EGISAPTrustlet.h
@@ -254,8 +254,8 @@ class EGISAPTrustlet : public QSEETrustlet {
     class API {
         // TODO: Could be a templated class defined in QSEETrustlet.
 
-        static constexpr auto RequestOffset = 0x5c;
-        static constexpr auto ResponseOffset = 0x14;
+        static inline constexpr auto RequestOffset = 0x5c;
+        static inline constexpr auto ResponseOffset = 0x14;
 
         QSEETrustlet::LockedIONBuffer mLockedBuffer;
 
@@ -275,7 +275,7 @@ class EGISAPTrustlet : public QSEETrustlet {
             memmove(&GetRequest(), &GetResponse(), sizeof(trustlet_buffer_t));
         }
 
-        inline static constexpr size_t BufferSize() {
+        static inline constexpr size_t BufferSize() {
             return sizeof(trustlet_buffer_t) + std::max(RequestOffset, ResponseOffset);
         }
 

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -203,10 +203,11 @@ err_t fpc_set_auth_challenge(fpc_imp_data_t *data, int64_t challenge)
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    fpc_send_auth_cmd_t auth_cmd = {0};
-    auth_cmd.group_id = FPC_GROUP_FPCDATA;
-    auth_cmd.cmd_id = FPC_SET_AUTH_CHALLENGE;
-    auth_cmd.challenge = challenge;
+    fpc_send_auth_cmd_t auth_cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_SET_AUTH_CHALLENGE,
+        .challenge = challenge,
+    };
 
     if(send_custom_cmd(ldata, &auth_cmd, sizeof(auth_cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
@@ -221,9 +222,10 @@ int64_t fpc_load_auth_challenge(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_load_auth_challenge_t cmd = {0};
-    cmd.group_id = FPC_GROUP_FPCDATA;
-    cmd.cmd_id = FPC_GET_AUTH_CHALLENGE;
+    fpc_load_auth_challenge_t cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_GET_AUTH_CHALLENGE,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
@@ -246,9 +248,10 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
     if(ldata->auth_id) {
         return ldata->auth_id;
     }
-    fpc_get_db_id_cmd_t cmd = {0};
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_GET_TEMPLATE_ID;
+    fpc_get_db_id_cmd_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_GET_TEMPLATE_ID,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to TZ\n");
@@ -262,12 +265,13 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
 err_t fpc_get_hw_auth_obj(fpc_imp_data_t *data, void * buffer, uint32_t length)
 {
     ALOGV(__func__);
-    fpc_get_auth_result_t cmd = {0};
     fpc_data_t *ldata = (fpc_data_t*)data;
+    fpc_get_auth_result_t cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_GET_AUTH_RESULT,
+        .length = AUTH_RESULT_LENGTH,
+    };
 
-    cmd.group_id = FPC_GROUP_FPCDATA;
-    cmd.cmd_id = FPC_GET_AUTH_RESULT;
-    cmd.length = AUTH_RESULT_LENGTH;
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
@@ -302,10 +306,11 @@ err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id)
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    fpc_fingerprint_delete_t cmd = {0};
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_DELETE_FINGERPRINT;
-    cmd.fingerprint_id = id;
+    fpc_fingerprint_delete_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_DELETE_FINGERPRINT,
+        .fingerprint_id = id,
+    };
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0)
@@ -389,9 +394,10 @@ err_t fpc_enroll_step(fpc_imp_data_t *data, uint32_t *remaining_touches)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_enrol_step_t cmd = {0};
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_ENROL_STEP;
+    fpc_enrol_step_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_ENROL_STEP,
+    };
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret <0)
@@ -424,9 +430,10 @@ err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_end_enrol_t cmd = {0};
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_END_ENROL;
+    fpc_end_enrol_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_END_ENROL,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending enrol command\n");
@@ -453,9 +460,11 @@ err_t fpc_auth_start(fpc_imp_data_t __unused  *data)
 err_t fpc_auth_step(fpc_imp_data_t *data, uint32_t *print_id)
 {
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_send_identify_t identify_cmd = {0};
-    identify_cmd.commandgroup = FPC_GROUP_NORMAL;
-    identify_cmd.command = FPC_IDENTIFY;
+    fpc_send_identify_t identify_cmd = {
+        .commandgroup = FPC_GROUP_NORMAL,
+        .command = FPC_IDENTIFY,
+    };
+
     int result = send_custom_cmd(ldata, &identify_cmd, sizeof(identify_cmd));
     if(result)
     {
@@ -486,7 +495,7 @@ fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_fingerprint_index_t idx_data = {0};
+    fpc_fingerprint_index_t idx_data = {};
     fpc_fingerprint_list_t cmd = {
         .group_id = FPC_GROUP_NORMAL,
         .cmd_id = FPC_GET_FINGERPRINTS,
@@ -545,10 +554,11 @@ err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid)
 {
     int result;
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_set_gid_t cmd = {0};
-    cmd.group_id = FPC_GROUP_NORMAL;
-    cmd.cmd_id = FPC_SET_GID;
-    cmd.gid = gid;
+    fpc_set_gid_t cmd = {
+        .group_id = FPC_GROUP_NORMAL,
+        .cmd_id = FPC_SET_GID,
+        .gid = gid,
+    };
 
     ALOGD("Setting GID to %d\n", gid);
     result = send_custom_cmd(ldata, &cmd, sizeof(cmd));

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -213,10 +213,11 @@ err_t fpc_set_auth_challenge(fpc_imp_data_t *data, int64_t challenge)
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    fpc_send_auth_cmd_t auth_cmd = {0};
-    auth_cmd.group_id = FPC_GROUP_FPCDATA;
-    auth_cmd.cmd_id = FPC_SET_AUTH_CHALLENGE;
-    auth_cmd.challenge = challenge;
+    fpc_send_auth_cmd_t auth_cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_SET_AUTH_CHALLENGE,
+        .challenge = challenge,
+    };
 
     if(send_custom_cmd(ldata, &auth_cmd, sizeof(auth_cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
@@ -231,9 +232,10 @@ int64_t fpc_load_auth_challenge(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_load_auth_challenge_t cmd = {0};
-    cmd.group_id = FPC_GROUP_FPCDATA;
-    cmd.cmd_id = FPC_GET_AUTH_CHALLENGE;
+    fpc_load_auth_challenge_t cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_GET_AUTH_CHALLENGE,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
@@ -256,9 +258,10 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
     if(ldata->auth_id > 0) {
         return ldata->auth_id;
     }
-    fpc_get_db_id_cmd_t cmd = {0};
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_GET_TEMPLATE_ID;
+    fpc_get_db_id_cmd_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_GET_TEMPLATE_ID,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to TZ\n");
@@ -272,12 +275,13 @@ int64_t fpc_load_db_id(fpc_imp_data_t *data)
 err_t fpc_get_hw_auth_obj(fpc_imp_data_t *data, void * buffer, uint32_t length)
 {
     ALOGV(__func__);
-    fpc_get_auth_result_t cmd = {0};
     fpc_data_t *ldata = (fpc_data_t*)data;
+    fpc_get_auth_result_t cmd = {
+        .group_id = FPC_GROUP_FPCDATA,
+        .cmd_id = FPC_GET_AUTH_RESULT,
+        .length = AUTH_RESULT_LENGTH,
+    };
 
-    cmd.group_id = FPC_GROUP_FPCDATA;
-    cmd.cmd_id = FPC_GET_AUTH_RESULT;
-    cmd.length = AUTH_RESULT_LENGTH;
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending data to tz\n");
         return -1;
@@ -312,10 +316,11 @@ err_t fpc_del_print_id(fpc_imp_data_t *data, uint32_t id)
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
 
-    fpc_fingerprint_delete_t cmd = {0};
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_DELETE_FINGERPRINT;
-    cmd.fingerprint_id = id;
+    fpc_fingerprint_delete_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_DELETE_FINGERPRINT,
+        .fingerprint_id = id,
+    };
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret < 0)
@@ -399,9 +404,10 @@ err_t fpc_enroll_step(fpc_imp_data_t *data, uint32_t *remaining_touches)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_enrol_step_t cmd = {0};
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_ENROL_STEP;
+    fpc_enrol_step_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_ENROL_STEP,
+    };
 
     int ret = send_custom_cmd(ldata, &cmd, sizeof(cmd));
     if(ret <0)
@@ -434,9 +440,10 @@ err_t fpc_enroll_end(fpc_imp_data_t *data, uint32_t *print_id)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_end_enrol_t cmd = {0};
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_END_ENROL;
+    fpc_end_enrol_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_END_ENROL,
+    };
 
     if(send_custom_cmd(ldata, &cmd, sizeof(cmd)) < 0) {
         ALOGE("Error sending enrol command\n");
@@ -462,10 +469,11 @@ err_t fpc_auth_start(fpc_imp_data_t __unused  *data)
 err_t fpc_auth_step(fpc_imp_data_t *data, uint32_t *print_id)
 {
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_send_identify_t identify_cmd = {0};
+    fpc_send_identify_t identify_cmd = {
+        .commandgroup = FPC_GROUP_TEMPLATE,
+        .command = FPC_IDENTIFY,
+    };
 
-    identify_cmd.commandgroup = FPC_GROUP_TEMPLATE;
-    identify_cmd.command = FPC_IDENTIFY;
     int result = send_custom_cmd(ldata, &identify_cmd, sizeof(identify_cmd));
     if(result)
     {
@@ -490,7 +498,7 @@ fpc_fingerprint_index_t fpc_get_print_index(fpc_imp_data_t *data)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_fingerprint_index_t idx_data = {0};
+    fpc_fingerprint_index_t idx_data = {};
     fpc_fingerprint_list_t cmd = {
         .group_id = FPC_GROUP_TEMPLATE,
         .cmd_id = FPC_GET_FINGERPRINTS,
@@ -549,10 +557,11 @@ err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid)
 {
     int result;
     fpc_data_t *ldata = (fpc_data_t*)data;
-    fpc_set_gid_t cmd = {0};
-    cmd.group_id = FPC_GROUP_TEMPLATE;
-    cmd.cmd_id = FPC_SET_GID;
-    cmd.gid = gid;
+    fpc_set_gid_t cmd = {
+        .group_id = FPC_GROUP_TEMPLATE,
+        .cmd_id = FPC_SET_GID,
+        .gid = gid,
+    };
 
     ALOGD("Setting GID to %d\n", gid);
     result = send_custom_cmd(ldata, &cmd, sizeof(cmd));


### PR DESCRIPTION
https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/43#issuecomment-452705292

This is a correctness issue that is tolerated on the Android 9 cross-compiler, but not on android 8.
Instead of declaring the variables in a compiler unit, use `inline` and switch to `c++17` for `static inline` member variables.

Furthermore, address a bunch of warnings related to misused structure initializers.
There's still:
```c++
hardware/sony/fingerprint/BiometricsFingerprint.cpp:583:68: warning: format specifies type 'unsigned long' but the argument has type 'unsigned long long' [-Wformat]
                        ALOGI("%s : hat->timestamp %lu", __func__, bswap_64(hat.timestamp));
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                                   %llu
```
on android 8, but it's the other way around on android 9. This is not fixed, because the format warning is a hard error on 9.

Build-tested on Android 8 for suzu and discovery.
Tested on Suzu and Akatsuki, android 9: enumerate, authenticate, remove and enroll.