### PR TITLE
[WIP] Android.mk: Build with static lib

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -29,6 +29,9 @@ LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 LOCAL_CFLAGS += -DUSE_FPC_TAMA
 endif
 
+LOCAL_STATIC_LIBRARIES := \
+    android.hardware.biometrics.fingerprint@2.1-impl
+
 LOCAL_SHARED_LIBRARIES := \
     libcutils \
     liblog \


### PR DESCRIPTION
Bring in line with other vendor HALs that link the HAL implementation lib statically.
C.f. https://android.googlesource.com/device/google/crosshatch/+/9f496ee376a456f97a09e1a407c37a181d04e581%5E%21/device.mk