### PR TITLE
Egistec: Correct | EPOLLIN to & EPOLLIN for correctness.

### DIFF
--- a/EgisOperationLoops.cpp
+++ b/EgisOperationLoops.cpp
@@ -169,13 +169,13 @@ EgisOperationLoops::WakeupReason EgisOperationLoops::WaitForEvent(int timeoutSec
     // Control events have priority over finger events, since
     // this is probably a request to cancel the current operation.
     for (auto ei = 0; ei < cnt; ++ei)
-        if (events[ei].data.fd == event_fd && events[ei].events | EPOLLIN) {
+        if (events[ei].data.fd == event_fd && events[ei].events & EPOLLIN) {
             ALOGD("%s: WakeupReason = Event", __func__);
             return WakeupReason::Event;
         }
 
     for (auto ei = 0; ei < cnt; ++ei)
-        if (events[ei].data.fd == mDev.GetDescriptor() && events[ei].events | EPOLLIN) {
+        if (events[ei].data.fd == mDev.GetDescriptor() && events[ei].events & EPOLLIN) {
             ALOGD("%s: WakeupReason = Finger", __func__);
             return WakeupReason::Finger;
         }


### PR DESCRIPTION
This operation is supposed to be an AND operation, to mask the EPOLLIN
bit out and only proceed if it's set.
In this case it doesn't matter and has no effect on the code flow, since
the poll is only requested for EPOLLIN (meaning that if it triggers, it
can only be that). Fix it nevertheless for code readability and
correctness, as well as to prevent accepting EPOLLERR or EPOLLHUP as
valid triggers.