### PR TITLE
[1/3] Implement Egistec HAL for Ganges

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,20 +13,35 @@ LOCAL_SRC_FILES := \
 
 ifeq ($(filter-out loire tone,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_loire_tone.c
+HAS_FPC := true
 endif
 
 ifeq ($(filter-out yoshino,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
+HAS_FPC := true
 endif
 
 ifeq ($(filter-out nile,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
+HAS_FPC := true
 LOCAL_CFLAGS += -DUSE_FPC_NILE
 endif
 
 ifeq ($(filter-out tama,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
+HAS_FPC := true
 LOCAL_CFLAGS += -DUSE_FPC_TAMA
+endif
+
+ifeq ($(filter-out ganges,$(SOMC_PLATFORM)),)
+LOCAL_CFLAGS += -DUSE_FPC_GANGES
+endif
+
+ifneq ($(HAS_FPC),true)
+# This file heavily depends on fpc_ implementations from the
+# above fpc_imp_* files. There is no sensible default file
+# on some platforms, so just remove the file altogether:
+LOCAL_SRC_FILES -= BiometricsFingerprint.cpp
 endif
 
 LOCAL_SHARED_LIBRARIES := \

--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -27,15 +27,11 @@
 
 #include "android-base/macros.h"
 
-namespace android {
-namespace hardware {
-namespace biometrics {
-namespace fingerprint {
-namespace V2_1 {
-namespace implementation {
+namespace fpc {
 
-using RequestStatus =
-        android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
+using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintAcquiredInfo;
+using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintError;
+using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
 
 BiometricsFingerprint *BiometricsFingerprint::sInstance = nullptr;
 
@@ -633,9 +629,4 @@ void BiometricsFingerprint::process_auth(sony_fingerprint_device_t *sdev) {
         mClientCallback->onError(devId, FingerprintError::ERROR_HW_UNAVAILABLE, 0);
 }
 
-} // namespace implementation
-}  // namespace V2_1
-}  // namespace fingerprint
-}  // namespace biometrics
-}  // namespace hardware
-}  // namespace android
+}  // namespace fpc

--- a/BiometricsFingerprint.h
+++ b/BiometricsFingerprint.h
@@ -34,18 +34,14 @@ extern "C" {
     #include "fpc_imp.h"
 }
 
-namespace android {
-namespace hardware {
-namespace biometrics {
-namespace fingerprint {
-namespace V2_1 {
-namespace implementation {
+namespace fpc {
 
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprintClientCallback;
 using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
 using ::android::hardware::Return;
 using ::android::hardware::Void;
+using ::android::hardware::hidl_array;
 using ::android::hardware::hidl_vec;
 using ::android::hardware::hidl_string;
 using ::android::sp;
@@ -118,11 +114,6 @@ private:
     sony_fingerprint_device_t *mDevice;
 };
 
-}  // namespace implementation
-}  // namespace V2_1
-}  // namespace fingerprint
-}  // namespace biometrics
-}  // namespace hardware
-}  // namespace android
+}  // namespace fpc
 
 #endif  // ANDROID_HARDWARE_BIOMETRICS_FINGERPRINT_V2_1_BIOMETRICSFINGERPRINT_H

--- a/IonBuffer.cpp
+++ b/IonBuffer.cpp
@@ -1,0 +1,117 @@
+#include "IonBuffer.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/msm_ion.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <algorithm>
+
+#define LOG_TAG "FPC"
+#include <log/log.h>
+
+int IonBuffer::ion_dev_fd = -1;
+
+int IonBuffer::IonDev() {
+    if (ion_dev_fd >= 0)
+        return ion_dev_fd;
+
+    ion_dev_fd = open("/dev/ion", O_RDONLY);
+    LOG_ALWAYS_FATAL_IF(ion_dev_fd < 0, "Failed to open /dev/ion: %s", strerror(errno));
+
+    return ion_dev_fd;
+}
+
+IonBuffer::IonBuffer(size_t sz) : mRequestedSize(sz), mSize((sz + ION_ALIGN_MASK) & ~ION_ALIGN_MASK) {
+    int rc = 0;
+
+    int ion_fd = IonDev();
+
+    /* Allocate buffer */
+
+    struct ion_allocation_data ion_alloc_data = {
+        .len = mSize,
+        .align = ION_ALIGN,
+        .heap_id_mask = ION_HEAP(ION_QSECOM_HEAP_ID),
+    };
+
+    rc = ioctl(ion_fd, ION_IOC_ALLOC, &ion_alloc_data);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to allocate ION buffer");
+
+    mHandle = ion_alloc_data.handle;
+
+    /* Map buffer to fd */
+
+    struct ion_fd_data ifd_data = {
+        .handle = mHandle,
+    };
+
+    rc = ioctl(ion_fd, ION_IOC_MAP, &ifd_data);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to map ION buffer");
+
+    mFd = ifd_data.fd;
+
+    mMapped = (unsigned char *)mmap(NULL, mSize,
+                                    PROT_READ | PROT_WRITE,
+                                    MAP_SHARED, ifd_data.fd, 0);
+    LOG_ALWAYS_FATAL_IF(mMapped == MAP_FAILED, "Failed to mmap ION buffer");
+}
+
+IonBuffer::~IonBuffer() {
+    int rc = 0;
+
+    if (mMapped) {
+        rc = munmap(mMapped, mSize);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to munmap ION buffer");
+        mMapped = nullptr;
+    }
+
+    if (mFd >= 0) {
+        rc = close(mFd);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to close ION buffer");
+        mFd = -1;
+    }
+
+    if (mHandle) {
+        struct ion_handle_data handle_data = {.handle = mHandle};
+        rc = ioctl(IonDev(), ION_IOC_FREE, &handle_data);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to free ION buffer");
+        mHandle = 0;
+    }
+
+    mSize = -1;
+}
+
+IonBuffer::IonBuffer(IonBuffer &&other) {
+    std::swap(mSize, other.mSize);
+    std::swap(mFd, other.mFd);
+    std::swap(mHandle, other.mHandle);
+    std::swap(mMapped, other.mMapped);
+}
+
+IonBuffer &IonBuffer::operator=(IonBuffer &&other) {
+    // Invoke move constructor:
+    return *new (this) IonBuffer(std::move(other));
+}
+
+size_t IonBuffer::size() const {
+    return mSize;
+}
+
+size_t IonBuffer::requestedSize() const {
+    return mRequestedSize;
+}
+
+int IonBuffer::fd() const {
+    return mFd;
+}
+
+void *IonBuffer::operator()() {
+    return mMapped;
+}
+
+const void *IonBuffer::operator()() const {
+    return mMapped;
+}

--- a/IonBuffer.h
+++ b/IonBuffer.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <stdint.h>
+// WARNING: Must include stdint before msm_ion, or it'll miss the size_t definition!
+#include <linux/msm_ion.h>
+
+class IonBuffer {
+    static constexpr size_t ION_ALIGN = 0x1000;
+    static constexpr size_t ION_ALIGN_MASK = ION_ALIGN - 1;
+
+    size_t mRequestedSize, mSize;
+    int mFd = -1;
+    ion_user_handle_t mHandle = 0;
+    void *mMapped = nullptr;
+
+    static int ion_dev_fd;
+    static int IonDev();
+
+   public:
+    IonBuffer(size_t);
+    ~IonBuffer();
+
+    IonBuffer(IonBuffer &&);
+    IonBuffer &operator=(IonBuffer &&);
+    IonBuffer(IonBuffer &) = delete;
+    const IonBuffer &operator=(const IonBuffer &) = delete;
+
+    size_t size() const;
+    size_t requestedSize() const;
+    int fd() const;
+
+    void *operator()();
+    const void *operator()() const;
+};
+
+template <typename T>
+class TypedIonBuffer : public IonBuffer {
+   public:
+    TypedIonBuffer() : IonBuffer(sizeof(T)) {
+    }
+
+    T *operator()() {
+        return (T *)IonBuffer::operator()();
+    }
+    const T *operator()() const {
+        return (T *)IonBuffer::operator()();
+    }
+    T *operator->() {
+        return (T *)IonBuffer::operator()();
+    }
+    const T *operator->() const {
+        return (T *)IonBuffer::operator()();
+    }
+    T &operator*() {
+        return *operator()();
+    }
+    const T &operator*() const {
+        return *operator()();
+    }
+};

--- a/QSEETrustlet.cpp
+++ b/QSEETrustlet.cpp
@@ -7,7 +7,7 @@
 #include "FormatException.hpp"
 
 #define LOG_TAG "FPC QSEETrustlet"
-#define LOG_NDEBUG 0
+// #define LOG_NDEBUG 0
 #include <log/log.h>
 
 #ifndef QSEE_LIBRARY

--- a/QSEETrustlet.cpp
+++ b/QSEETrustlet.cpp
@@ -19,6 +19,7 @@ void *QSEETrustlet::libHandle = nullptr;
 QSEETrustlet::start_app_def QSEETrustlet::start_app = nullptr;
 QSEETrustlet::shutdown_app_def QSEETrustlet::shutdown_app = nullptr;
 QSEETrustlet::send_cmd_def QSEETrustlet::send_cmd = nullptr;
+QSEETrustlet::send_modified_cmd_def QSEETrustlet::send_modified_cmd = nullptr;
 
 QSEETrustlet::QSEETrustlet(const char *app_name, uint32_t shared_buffer_size, const char *path) {
     EnsureInitialized();
@@ -68,6 +69,12 @@ void QSEETrustlet::EnsureInitialized() {
         ALOGE("Error loading QSEECom_send_cmd: %s\n", strerror(errno));
         throw FormatException("Failed to load QSEECom_send_cmd!");
     }
+
+    send_modified_cmd = (send_modified_cmd_def)dlsym(libHandle, "QSEECom_send_modified_cmd");
+    if (send_modified_cmd == nullptr) {
+        ALOGE("Error loading QSEECom_send_modified_cmd: %s\n", strerror(errno));
+        throw FormatException("Failed to load QSEECom_send_modified_cmd!");
+    }
 }
 
 QSEETrustlet::LockedIONBuffer QSEETrustlet::GetLockedBuffer() {
@@ -110,4 +117,8 @@ const void *QSEETrustlet::LockedIONBuffer::operator*() const {
 
 int QSEETrustlet::SendCommand(const void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len) {
     return send_cmd(mHandle, send_buf, sbuf_len, rcv_buf, rbuf_len);
+}
+
+int QSEETrustlet::SendModifiedCommand(const void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len, QSEECom_ion_fd_info *ifd_data) {
+    return send_modified_cmd(mHandle, send_buf, sbuf_len, rcv_buf, rbuf_len, ifd_data);
 }

--- a/QSEETrustlet.h
+++ b/QSEETrustlet.h
@@ -39,6 +39,7 @@ class QSEETrustlet {
 
     LockedIONBuffer GetLockedBuffer();
     int SendCommand(const void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len);
+    int SendModifiedCommand(const void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len, QSEECom_ion_fd_info *ifd_data);
 
    private:
     std::mutex mBufferMutex;
@@ -47,12 +48,13 @@ class QSEETrustlet {
     typedef int (*start_app_def)(struct QSEECom_handle **clnt_handle, const char *path, const char *fname, uint32_t sb_size);
     typedef int (*shutdown_app_def)(struct QSEECom_handle **clnt_handle);
     typedef int (*send_cmd_def)(struct QSEECom_handle *handle, const void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len);
-    // typedef int (*send_modified_cmd_def)(struct QSEECom_handle *handle, void *send_buf, uint32_t sbuf_len, void *resp_buf, uint32_t rbuf_len, struct QSEECom_ion_fd_info *ifd_data);
+    typedef int (*send_modified_cmd_def)(struct QSEECom_handle *handle, const void *send_buf, uint32_t sbuf_len, void *resp_buf, uint32_t rbuf_len, struct QSEECom_ion_fd_info *ifd_data);
 
     static void *libHandle;
     static start_app_def start_app;
     static shutdown_app_def shutdown_app;
     static send_cmd_def send_cmd;
+    static send_modified_cmd_def send_modified_cmd;
 
     static void EnsureInitialized();
 };

--- a/WorkerThread.cpp
+++ b/WorkerThread.cpp
@@ -1,0 +1,172 @@
+#include "WorkerThread.h"
+
+#if PLATFORM_SDK_VERSION >= 28
+#include <bits/epoll_event.h>
+#endif
+#include <errno.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/poll.h>
+#include <FormatException.hpp>
+
+#define LOG_TAG "FPC"
+#define LOG_NDEBUG 0
+#include <log/log.h>
+
+WorkerThread::WorkerThread(WorkHandler *handler, int dev_fd) : dev_fd(dev_fd), mHandler(handler) {
+    int rc = 0;
+
+    LOG_ALWAYS_FATAL_IF(!mHandler, "WorkHandler is null!");
+
+    event_fd = eventfd((eventfd_t)AsyncState::Idle, EFD_NONBLOCK);
+    LOG_ALWAYS_FATAL_IF(event_fd < 0, "Failed to create eventfd: %s", strerror(errno));
+    epoll_fd = epoll_create1(0);
+    LOG_ALWAYS_FATAL_IF(epoll_fd < 0, "Failed to create epoll: %s", strerror(errno));
+
+    struct epoll_event ev = {
+        .data.fd = event_fd,
+        .events = EPOLLIN,
+    };
+    rc = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, event_fd, &ev);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to add eventfd %d to epoll: %s", event_fd, strerror(errno));
+
+    ev = {
+        .data.fd = dev_fd,
+        .events = EPOLLIN,
+    };
+    rc = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, ev.data.fd, &ev);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to add fingerprint device %d to epoll: %s", dev_fd, strerror(errno));
+
+    thread = std::thread(ThreadStart, this);
+}
+
+void *WorkerThread::ThreadStart(void *arg) {
+    auto &self = *static_cast<WorkerThread *>(arg);
+    self.RunThread();
+    return nullptr;
+}
+
+void WorkerThread::RunThread() {
+    ALOGD("Async thread up");
+    for (;;) {
+        // NOTE: Not using WaitForEvent() here, because we are not interested
+        // in wakeups from the fp device, only in events.
+        struct pollfd pfd = {
+            .fd = event_fd,
+            .events = POLLIN,
+        };
+        int cnt = poll(&pfd, 1, -1);
+        if (cnt <= 0) {
+            ALOGW("Infinite poll returned with %d", cnt);
+            continue;
+        }
+
+        auto nextState = ReadState();
+        currentState = nextState;
+        switch (nextState) {
+            case AsyncState::Idle:
+                // Poll should not return on Idle
+                ALOGW("Unexpected AsyncState::Idle");
+                break;
+            case AsyncState::Cancel:
+                ALOGW("Unexpected AsyncState::Cancel - nothing in progress");
+                break;
+            case AsyncState::Authenticate:
+                mHandler->AuthenticateAsync();
+                break;
+            case AsyncState::Enroll:
+                mHandler->EnrollAsync();
+                break;
+            default:
+                ALOGW("Unexpected AsyncState %lu", nextState);
+                break;
+        }
+        currentState = AsyncState::Idle;
+    }
+}
+
+AsyncState WorkerThread::ReadState() {
+    eventfd_t requestedState;
+    AsyncState state = AsyncState::Idle;
+
+    int rc = eventfd_read(event_fd, &requestedState);
+    // When nothing is read (no event is available), it's Idle.
+    if (!rc)
+        state = static_cast<AsyncState>(requestedState);
+
+    return state;
+}
+
+bool WorkerThread::IsCanceled() {
+    auto state = ReadState();
+    if (state == AsyncState::Cancel)
+        return true;
+
+    if (state != AsyncState::Idle)
+        // Reading a state consumes it from the eventfd, clearing it.
+        ALOGW("%s: Consumed unexpected state %lu. This state will NOT be processed", __func__, state);
+
+    return false;
+}
+
+bool WorkerThread::MoveToState(AsyncState nextState) {
+    ALOGD("Attempting to move to state %lu", nextState);
+    // TODO: This is racy (eg. does not look at in-flight state),
+    // but it does not matter because async operations are not supposed to be
+    // invoked concurrently (how can a device run any combination of authenticate or
+    // enroll simultaneously??). The thread will simply reject it in that case.
+
+    // Currently, the service that uses this HAL (FingerprintService.java) calls cancel() in
+    // such a case, and only starts the next operation upon receiving FingerprintError::ERROR_CANCELED.
+
+    if (nextState != AsyncState::Cancel && currentState != AsyncState::Idle) {
+        ALOGW("Thread already in state %lu, refusing to move to %lu", currentState, nextState);
+        return false;
+    }
+
+    int rc = eventfd_write(event_fd, (eventfd_t)nextState);
+    if (rc) {
+        ALOGE("Failed to write next state to eventfd: %s", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+WakeupReason WorkerThread::WaitForEvent(int timeoutSec) {
+    constexpr auto EVENT_COUNT = 2;
+    struct epoll_event events[EVENT_COUNT];
+    ALOGD("%s: TimeoutSec = %d", __func__, timeoutSec);
+    int cnt = epoll_wait(epoll_fd, events, EVENT_COUNT, 1000 * timeoutSec);
+
+    if (cnt < 0) {
+        ALOGE("%s: epoll_wait failed: %s", __func__, strerror(errno));
+        // Let the current operation continue as if nothing happened:
+        return WakeupReason::Timeout;
+    }
+
+    if (!cnt) {
+        ALOGD("%s: WakeupReason = Timeout", __func__);
+        return WakeupReason::Timeout;
+    }
+
+    bool finger_event = false;
+
+    for (auto ei = 0; ei < cnt; ++ei)
+        if (events[ei].events & EPOLLIN) {
+            // Control events have priority over finger events, since
+            // this is probably a request to cancel the current operation.
+            if (events[ei].data.fd == event_fd) {
+                ALOGD("%s: WakeupReason = Event", __func__);
+                return WakeupReason::Event;
+            } else if (events[ei].data.fd == dev_fd) {
+                finger_event = true;
+            }
+        }
+
+    if (finger_event) {
+        ALOGD("%s: WakeupReason = Finger", __func__);
+        return WakeupReason::Finger;
+    }
+
+    throw FormatException("Invalid fd source!");
+}

--- a/WorkerThread.h
+++ b/WorkerThread.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <sys/eventfd.h>
+#include <thread>
+
+enum class AsyncState : eventfd_t {
+    Idle = 0,
+    Cancel,
+    Authenticate,
+    Enroll,
+};
+
+enum class WakeupReason {
+    Timeout,
+    Event,
+    Finger,  // Hardware
+};
+
+struct WorkHandler {
+    virtual void AuthenticateAsync() = 0;
+    virtual void EnrollAsync() = 0;
+
+    inline virtual ~WorkHandler() {
+    }
+};
+
+class WorkerThread {
+    AsyncState currentState = AsyncState::Idle;
+    int dev_fd;
+    int epoll_fd;
+    int event_fd;
+    std::thread thread;
+    WorkHandler *mHandler;
+
+    static void *ThreadStart(void *);
+    void RunThread();
+
+   public:
+    WorkerThread(WorkHandler *handler, int dev_fd);
+
+    AsyncState ReadState();
+    bool IsCanceled();
+    bool MoveToState(AsyncState);
+    WakeupReason WaitForEvent(int timeoutSec = -1);
+};

--- a/WorkerThread.h
+++ b/WorkerThread.h
@@ -19,6 +19,8 @@ enum class WakeupReason {
 struct WorkHandler {
     virtual void AuthenticateAsync() = 0;
     virtual void EnrollAsync() = 0;
+    inline virtual void OnEnterIdle() {
+    }
 
     inline virtual ~WorkHandler() {
     }

--- a/egistec/EgisFpDevice.cpp
+++ b/egistec/EgisFpDevice.cpp
@@ -4,7 +4,9 @@
 #include <poll.h>
 #include <string.h>
 #include <unistd.h>
-#include "FormatException.hpp"
+#include <FormatException.hpp>
+
+namespace egistec {
 
 struct ioctl_cmd {
     int interurpt_mode;
@@ -62,6 +64,7 @@ int EgisFpDevice::GetDescriptor() const {
     return mFd;
 }
 
+#ifdef USE_FPC_NILE
 FpHwId EgisFpDevice::GetHwId() const {
     FpHwId id;
     int rc = ioctl(mFd, ET51X_IOCRHWTYPE, &id);
@@ -69,3 +72,6 @@ FpHwId EgisFpDevice::GetHwId() const {
         throw FormatException("Failed to determine HW id: %d", rc);
     return id;
 }
+#endif
+
+}  // namespace egistec

--- a/egistec/EgisFpDevice.cpp
+++ b/egistec/EgisFpDevice.cpp
@@ -60,7 +60,7 @@ bool EgisFpDevice::WaitInterrupt(int timeout) const {
     return rc && pfd.revents & POLLIN;
 }
 
-int EgisFpDevice::GetDescriptor() const {
+int EgisFpDevice::GetFd() const {
     return mFd;
 }
 

--- a/egistec/EgisFpDevice.h
+++ b/egistec/EgisFpDevice.h
@@ -17,6 +17,8 @@
 #define FP_HW_TYPE_EGISTEC 0
 #define FP_HW_TYPE_FPC 1
 
+namespace egistec {
+
 enum class FpHwId {
     Egistec = FP_HW_TYPE_EGISTEC,
     Fpc = FP_HW_TYPE_FPC,
@@ -45,6 +47,10 @@ class EgisFpDevice {
     int Disable() const;
     bool WaitInterrupt(int timeout = -1) const;
     int GetDescriptor() const;
+
+    // TODO: Move/abstract this if we ever get more
+    // platforms with multiple sensor types.
+#ifdef USE_FPC_NILE
     /**
      * Retrieve hardware ID from the FPC driver.
      * Currently only has a meaning on the Nile platform,
@@ -53,6 +59,7 @@ class EgisFpDevice {
      * return an error.
      */
     FpHwId GetHwId() const;
+#endif
 };
 
 /**
@@ -62,14 +69,16 @@ class EgisFpDevice {
 template <typename T>
 struct DeviceEnableGuard {
     const T &object;
-    DeviceEnableGuard(const T &t) : object(t) {
+    inline DeviceEnableGuard(const T &t) : object(t) {
         object.Enable();
     }
 
-    ~DeviceEnableGuard() {
+    inline ~DeviceEnableGuard() {
         object.Disable();
     }
 
     DeviceEnableGuard(DeviceEnableGuard &) = delete;
     DeviceEnableGuard &operator=(DeviceEnableGuard &) = delete;
 };
+
+}  // namespace egistec

--- a/egistec/EgisFpDevice.h
+++ b/egistec/EgisFpDevice.h
@@ -46,7 +46,7 @@ class EgisFpDevice {
      */
     int Disable() const;
     bool WaitInterrupt(int timeout = -1) const;
-    int GetDescriptor() const;
+    int GetFd() const;
 
     // TODO: Move/abstract this if we ever get more
     // platforms with multiple sensor types.

--- a/egistec/ganges/BiometricsFingerprint.cpp
+++ b/egistec/ganges/BiometricsFingerprint.cpp
@@ -29,12 +29,6 @@ BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : mDev(std::mov
 
     rc = mTrustlet.Calibrate();
     LOG_ALWAYS_FATAL_IF(rc, "Calibrate failed with rc = %d", rc);
-
-    // TODO: From thread
-    // Power saving?
-    rc = mTrustlet.SetWorkMode(2);
-    if (rc)
-        throw FormatException("SetWorkMode failed with rc = %d", rc);
 }
 
 Return<uint64_t> BiometricsFingerprint::setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) {
@@ -607,6 +601,12 @@ void BiometricsFingerprint::EnrollAsync() {
         rc = mTrustlet.SaveEnrolledPrint(mGid, mNewPrintId);
         ALOGE_IF(rc, "%s: Failed to save print, rc = %d", __func__, rc);
     }
+}
+
+void BiometricsFingerprint::OnEnterIdle() {
+    // Set the hardware back to idle state:
+    int rc = mTrustlet.SetWorkMode(2);
+    LOG_ALWAYS_FATAL_IF(rc, "SetWorkMode failed with rc = %d", rc);
 }
 
 void BiometricsFingerprint::NotifyAcquired(FingerprintAcquiredInfo acquiredInfo) {

--- a/egistec/ganges/BiometricsFingerprint.cpp
+++ b/egistec/ganges/BiometricsFingerprint.cpp
@@ -6,7 +6,7 @@
 
 namespace egistec::ganges {
 
-BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : mDev(std::move(dev)) {
+BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : mDev(std::move(dev)), mWt(this, mDev.GetFd()) {
     QSEEKeymasterTrustlet keymaster;
     int rc = 0;
 
@@ -48,37 +48,76 @@ Return<uint64_t> BiometricsFingerprint::setNotify(const sp<IBiometricsFingerprin
 }
 
 Return<uint64_t> BiometricsFingerprint::preEnroll() {
-    // TODO:
-    auto challenge = -1ul;
-    ALOGI("%s: Generated enroll challenge %#lx", __func__, challenge);
-    return challenge;
+    mEnrollChallenge = (uint64_t)rand() | (uint64_t)rand() << 0x20;
+    ALOGI("%s: Generated enroll challenge %#lx", __func__, mEnrollChallenge);
+    return mEnrollChallenge;
 }
 
-Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t /* timeoutSec */) {
-    if (gid != mGid) {
-        ALOGE("Cannot enroll finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
-        return RequestStatus::SYS_EINVAL;
-    }
+Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t timeoutSec) {
+    int rc = 0;
 
-    const auto h = reinterpret_cast<const hw_auth_token_t *>(hat.data());
-    if (!h) {
+    if (!hat.data()) {
         // This seems to happen when locking the device while enrolling.
         // It is unknown why this function is called again.
         ALOGE("%s: authentication token is unset!", __func__);
         return RequestStatus::SYS_EINVAL;
     }
 
-    ALOGI("Starting enroll for challenge %#lx", h->challenge);
-    // TODO:
+    if (gid != mGid) {
+        ALOGE("Cannot enroll finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    const auto &h = *reinterpret_cast<const hw_auth_token_t *>(hat.data());
+
+    ALOGI("Starting enroll for challenge %#lx", h.challenge);
+
+    if (mEnrollChallenge != h.challenge) {
+        ALOGE("HAT challenge doesn't match preEnroll-provided challenge!");
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    rc = mTrustlet.CheckAuthToken(h);
+    if (rc) {
+        ALOGE("Auth token invalid, rc = %d", rc);
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    rc = mTrustlet.CheckSecureId(gid, h.user_id);
+    if (rc) {
+        ALOGE("Secure id invalid, rc = %d", rc);
+        // TODO: This is where the HAL removes all fingerprints.
+        ALOGW("Not removing fingerprints. If you see this, delete the database and report the issue");
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    rc = mTrustlet.GetNewPrintId(gid, mNewPrintId);
+    if (rc == -2) {
+        ALOGE("%s: No space for new fingerprint", __func__);
+        return RequestStatus::SYS_ENOSPC;
+    } else if (rc) {
+        ALOGE("%s: Failed to get new print id, rc = %d", __func__, rc);
+        return RequestStatus::SYS_EFAULT;
+    }
+
+    ALOGI("New print id = %u", mNewPrintId);
+
+    mEnrollTimeout = timeoutSec;
+
+    if (mWt.MoveToState(AsyncState::Enroll))
+        return RequestStatus::SYS_OK;
+
     return RequestStatus::SYS_EFAULT;
-    // return loops.Enroll(*h, timeoutSec) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
 Return<RequestStatus> BiometricsFingerprint::postEnroll() {
     ALOGI("%s: clearing challenge", __func__);
-    // TODO:
-    return RequestStatus::SYS_EFAULT;
-    // return loops.ClearChallenge() ? RequestStatus::SYS_UNKNOWN : RequestStatus::SYS_OK;
+
+    mEnrollTimeout = -1;
+    mNewPrintId = -1;
+    mEnrollChallenge = 0;
+
+    return RequestStatus::SYS_OK;
 }
 
 Return<uint64_t> BiometricsFingerprint::getAuthenticatorId() {
@@ -89,9 +128,11 @@ Return<uint64_t> BiometricsFingerprint::getAuthenticatorId() {
 
 Return<RequestStatus> BiometricsFingerprint::cancel() {
     ALOGI("Cancel requested");
+
+    if (mWt.MoveToState(AsyncState::Cancel))
+        return RequestStatus::SYS_OK;
+
     return RequestStatus::SYS_EFAULT;
-    // bool success = loops.Cancel();
-    // return success ? RequestStatus::SYS_OK : RequestStatus::SYS_UNKNOWN;
 }
 
 Return<RequestStatus> BiometricsFingerprint::enumerate() {
@@ -141,6 +182,264 @@ Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operationId, 
 
     return RequestStatus::SYS_EFAULT;
     // return loops.Authenticate(operationId) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
+}
+
+void BiometricsFingerprint::AuthenticateAsync() {
+    // DeviceEnableGuard<EgisFpDevice> guard{mDev};
+}
+
+void BiometricsFingerprint::EnrollAsync() {
+    DeviceEnableGuard<EgisFpDevice> guard{mDev};
+
+    enum EnrollState {
+        WaitFingerDown,
+        GetImage,
+        EnrollStep,
+        WaitFingerLost,
+    };
+
+    int rc = 0;
+    EnrollState state = WaitFingerDown;
+    bool canceled = false, timeout = false;
+
+    // Progress reporting:
+    int finger_state = 0;
+    int percentage_done = 0;
+    int steps_done = 0;
+
+    // Only for local use within case statements:
+    enroll_result_t enroll_result;
+    ImageResult image_result;
+    int steps_needed;
+    WakeupReason wakeup_reason;
+
+    rc = mTrustlet.InitializeEnroll();
+    if (rc) {
+        ALOGE("%s: Failed to initialize enroll, rc = %d", __func__, rc);
+        NotifyError(FingerprintError::ERROR_UNABLE_TO_PROCESS);
+        return;
+    }
+
+    while (percentage_done < 100 && !canceled && !rc) {
+        if (mWt.IsCanceled()) {
+            canceled = true;
+            break;
+        }
+
+        ALOGI("%s: State = %d", __func__, state);
+        switch (state) {
+            case WaitFingerDown:
+                rc = mTrustlet.SetWorkMode(1);
+                ALOGE_IF(rc, "%s: Failed to set detect mode, rc = %d", __func__, rc);
+                if (rc)
+                    break;
+
+                wakeup_reason = mWt.WaitForEvent(mEnrollTimeout);
+                if (wakeup_reason == WakeupReason::Finger)
+                    finger_state = 1;
+                else if (wakeup_reason == WakeupReason::Timeout) {
+                    timeout = true;
+                    break;
+                } else {
+                    break;
+                }
+
+                // Could also be a fallthrough...
+                state = GetImage;
+                break;
+            case GetImage:
+                rc = mTrustlet.GetImage(image_result);
+                ALOGE_IF(rc, "%s: Failed to get image, rc = %d", __func__, rc);
+                if (rc)
+                    break;
+
+                state = WaitFingerLost;
+
+                switch (image_result) {
+                    case ImageResult::Good:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_GOOD);
+
+                        // Proceed to enroll step:
+                        state = EnrollStep;
+                        break;
+                    case ImageResult::TooFast:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_TOO_FAST);
+                        break;
+                    case ImageResult::Partial:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_PARTIAL);
+                        break;
+                    default:
+                        state = WaitFingerDown;
+                        break;
+                }
+
+                break;
+            case EnrollStep:
+                // Enroll only seems to do something when finger_state = 1
+                // Not sure what happens with finger_state = 2 below.
+                rc = mTrustlet.Enroll(finger_state, 0, enroll_result);
+                ALOGE_IF(rc, "%s: Failed to enroll, rc = %d", __func__, rc);
+                if (rc)
+                    break;
+
+                ALOGI("Enroll status = %d, at %d%%", enroll_result.status, enroll_result.percentage);
+                ALOGI("Enroll dx = %d, dy = %d, score = %d",
+                      enroll_result.dx, enroll_result.dy, enroll_result.score);
+
+                // Reset finger state for next step:
+                finger_state = 0;
+                state = WaitFingerLost;
+
+                percentage_done = enroll_result.percentage;
+
+                switch (enroll_result.status) {
+                    case ImageResult::Good: {
+                        steps_done++;
+
+                        // Usually 10 steps are needed:
+                        steps_needed = 10;
+                        if (percentage_done > 0)
+                            // Calculate required number of steps based on reported percentage (without floats):
+                            steps_needed = 100 * steps_done / percentage_done;
+
+                        NotifyEnrollResult(mNewPrintId, steps_needed - steps_done);
+                        break;
+                    }
+                    case ImageResult::Detected1:
+                    case ImageResult::Detected3:
+                        ALOGI("%s: Enroll() detected finger", __func__);
+                        // Sends ACQUIRED_VENDOR, or FINGERPRINT_ACQUIRED_DETECTED in old-skool libhardware
+                        break;
+                    case ImageResult::ImagerDirty:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_IMAGER_DIRTY);
+                        break;
+                    case ImageResult::Partial:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_PARTIAL);
+                        break;
+                    case ImageResult::Nothing:
+                        // Nothing to add or improve, continue with the loop
+                        break;
+                    default:
+                        ALOGE("Unknown enroll state %d", enroll_result.status);
+                        rc = -1;
+                        break;
+                }
+                break;
+            case WaitFingerLost:
+                rc = mTrustlet.SetSpiState(1);
+                ALOGE_IF(rc, "%s: Failed to set SPI on, rc = %d", __func__, rc);
+                if (rc)
+                    break;
+                rc = mTrustlet.IsFingerLost(30, image_result);
+                if (rc)
+                    break;
+
+                if (image_result == ImageResult::Lost) {
+                    finger_state = 2;
+
+                    rc = mTrustlet.Enroll(finger_state, 0, enroll_result);
+                    ALOGE_IF(rc, "%s: Failed to Enroll(2), rc = %d", __func__, rc);
+                    if (rc)
+                        break;
+                    rc = mTrustlet.SetSpiState(0);
+                    ALOGE_IF(rc, "%s: Failed to set SPI off, rc = %d", __func__, rc);
+                    if (rc)
+                        break;
+                    // Proceed to next touch-step
+                    state = WaitFingerDown;
+                } else if (image_result == ImageResult::DirtOnSensor)
+                    NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_IMAGER_DIRTY);
+                else {
+                    // NOTE: Based on authentication loop!
+
+                    wakeup_reason = mWt.WaitForEvent(mEnrollTimeout);
+                    if (wakeup_reason == WakeupReason::Timeout)
+                        timeout = true;
+                }
+                break;
+        }
+    }
+
+    ALOGI("%s: Finalizing, Percentage = %d%%", __func__, percentage_done);
+
+    rc = mTrustlet.FinalizeEnroll();
+    ALOGE_IF(rc, "%s: Failed to uninitialize enroll, rc = %d", __func__, rc);
+
+    if (canceled) {
+        ALOGI("%s: Canceled", __func__);
+        NotifyError(FingerprintError::ERROR_CANCELED);
+    } else if (timeout) {
+        ALOGI("%s: Timeout", __func__);
+        NotifyError(FingerprintError::ERROR_TIMEOUT);
+    } else if (rc) {
+        ALOGI("%s: Finalizing with error %d", __func__, rc);
+        NotifyError(FingerprintError::ERROR_UNABLE_TO_PROCESS);
+    } else if (percentage_done >= 100) {
+        rc = mTrustlet.SaveEnrolledPrint(mGid, mNewPrintId);
+        ALOGE_IF(rc, "%s: Failed to save print, rc = %d", __func__, rc);
+    }
+}
+
+void BiometricsFingerprint::NotifyAcquired(FingerprintAcquiredInfo acquiredInfo) {
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    // Same here: No vendor acquire strings have been defined in an overlay.
+    if (mClientCallback == nullptr)
+        ALOGW("Client callback not set");
+    else
+        mClientCallback->onAcquired(reinterpret_cast<uint64_t>(this),
+                                    std::min(acquiredInfo, FingerprintAcquiredInfo::ACQUIRED_VENDOR),
+                                    acquiredInfo >= FingerprintAcquiredInfo::ACQUIRED_VENDOR ? (int32_t)acquiredInfo : 0);
+}
+
+void BiometricsFingerprint::NotifyAuthenticated(uint32_t fid, const hw_auth_token_t &hat) {
+    auto hat_p = reinterpret_cast<const uint8_t *>(&hat);
+    const hidl_vec<uint8_t> token(hat_p, hat_p + sizeof(hw_auth_token_t));
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    if (mClientCallback == nullptr)
+        ALOGW("Client callback not set");
+    else
+        mClientCallback->onAuthenticated(reinterpret_cast<uint64_t>(this),
+                                         fid,
+                                         mGid,
+                                         token);
+}
+
+void BiometricsFingerprint::NotifyEnrollResult(uint32_t fid, uint32_t remaining) {
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    if (mClientCallback == nullptr)
+        ALOGW("Client callback not set");
+    else
+        mClientCallback->onEnrollResult(reinterpret_cast<uint64_t>(this), fid, mGid, remaining);
+}
+
+void BiometricsFingerprint::NotifyError(FingerprintError e) {
+    if ((uint32_t)e >= (uint32_t)FingerprintError::ERROR_VENDOR)
+        // No custom error strings for vendor codes are defined.
+        // Convert every unknown error code to the generic unable_to_proces.
+
+        // Do not use HW_UNAVAILABLE here, that causes the FingerprintService
+        // to move on to "the next" HAL (which will loop around to use this HAL again),
+        // but messes up state in the process (for example, receiving a second
+        // authentication request when leaving the menu).
+        e = FingerprintError::ERROR_UNABLE_TO_PROCESS;
+
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    if (mClientCallback == nullptr)
+        ALOGW("Client callback not set");
+    else
+        mClientCallback->onError(reinterpret_cast<uint64_t>(this), e, 0);
+}
+
+void BiometricsFingerprint::NotifyRemove(uint32_t fid, uint32_t remaining) {
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    if (mClientCallback == nullptr)
+        ALOGW("Client callback not set");
+    else
+        mClientCallback->onRemoved(
+            reinterpret_cast<uint64_t>(this),
+            fid,
+            mGid,
+            remaining);
 }
 
 }  // namespace egistec::ganges

--- a/egistec/ganges/BiometricsFingerprint.cpp
+++ b/egistec/ganges/BiometricsFingerprint.cpp
@@ -1,0 +1,116 @@
+#include "BiometricsFingerprint.h"
+#include <hardware/hw_auth_token.h>
+#include "FormatException.hpp"
+
+#define LOG_TAG "FPC ET"
+#include <log/log.h>
+
+namespace egistec::ganges {
+
+BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : mDev(std::move(dev)) {
+    QSEEKeymasterTrustlet keymaster;
+    mMasterKey = keymaster.GetKey();
+
+    // int rc = loops.Prepare();
+    // if (rc)
+    //     throw FormatException("Prepare failed with rc = %d", rc);
+
+    // rc = loops.SetMasterKey(mMasterKey);
+    // if (rc)
+    //     throw FormatException("SetMasterKey failed with rc = %d", rc);
+}
+
+Return<uint64_t> BiometricsFingerprint::setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) {
+    std::lock_guard<std::mutex> lock(mClientCallbackMutex);
+    mClientCallback = clientCallback;
+    // This is here because HAL 2.1 doesn't have a way to propagate a
+    // unique token for its driver. Subsequent versions should send a unique
+    // token for each call to setNotify(). This is fine as long as there's only
+    // one fingerprint device on the platform.
+    return reinterpret_cast<uint64_t>(this);
+}
+
+Return<uint64_t> BiometricsFingerprint::preEnroll() {
+    // TODO:
+    auto challenge = -1ul;
+    ALOGI("%s: Generated enroll challenge %#lx", __func__, challenge);
+    return challenge;
+}
+
+Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t /* timeoutSec */) {
+    if (gid != mGid) {
+        ALOGE("Cannot enroll finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    const auto h = reinterpret_cast<const hw_auth_token_t *>(hat.data());
+    if (!h) {
+        // This seems to happen when locking the device while enrolling.
+        // It is unknown why this function is called again.
+        ALOGE("%s: authentication token is unset!", __func__);
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    ALOGI("Starting enroll for challenge %#lx", h->challenge);
+    // TODO:
+    return RequestStatus::SYS_EFAULT;
+    // return loops.Enroll(*h, timeoutSec) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
+}
+
+Return<RequestStatus> BiometricsFingerprint::postEnroll() {
+    ALOGI("%s: clearing challenge", __func__);
+    // TODO:
+    return RequestStatus::SYS_EFAULT;
+    // return loops.ClearChallenge() ? RequestStatus::SYS_UNKNOWN : RequestStatus::SYS_OK;
+}
+
+Return<uint64_t> BiometricsFingerprint::getAuthenticatorId() {
+    // TODO:
+    auto id = -1ul;
+    ALOGI("%s: id = %lu", __func__, id);
+    return id;
+    // return loops.GetAuthenticatorId();
+}
+
+Return<RequestStatus> BiometricsFingerprint::cancel() {
+    ALOGI("Cancel requested");
+    return RequestStatus::SYS_EFAULT;
+    // bool success = loops.Cancel();
+    // return success ? RequestStatus::SYS_OK : RequestStatus::SYS_UNKNOWN;
+}
+
+Return<RequestStatus> BiometricsFingerprint::enumerate() {
+    return RequestStatus::SYS_EFAULT;
+    // return loops.Enumerate() ? RequestStatus::SYS_UNKNOWN : RequestStatus::SYS_OK;
+}
+
+Return<RequestStatus> BiometricsFingerprint::remove(uint32_t gid, uint32_t fid) {
+    ALOGI("%s: gid = %d, fid = %d", __func__, gid, fid);
+    if (gid != mGid) {
+        ALOGE("Change group and userpath through setActiveGroup first!");
+        return RequestStatus::SYS_EINVAL;
+    }
+    return RequestStatus::SYS_EFAULT;
+    // return loops.RemoveFinger(fid) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
+}
+
+Return<RequestStatus> BiometricsFingerprint::setActiveGroup(uint32_t gid, const hidl_string &storePath) {
+    ALOGI("%s: gid = %u, path = %s", __func__, gid, storePath.c_str());
+    mGid = gid;
+    return RequestStatus::SYS_EFAULT;
+    // int rc = loops.SetUserDataPath(mGid, storePath.c_str());
+    // return rc ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
+}
+
+Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operationId, uint32_t gid) {
+    ALOGI("%s: gid = %d, secret = %lu", __func__, gid, operationId);
+    if (gid != mGid) {
+        ALOGE("Cannot authenticate finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
+        return RequestStatus::SYS_EINVAL;
+    }
+
+    return RequestStatus::SYS_EFAULT;
+    // return loops.Authenticate(operationId) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
+}
+
+}  // namespace egistec::ganges

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -6,6 +6,7 @@
 
 #include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
 
+#include <WorkerThread.h>
 #include <egistec/EgisFpDevice.h>
 #include <array>
 #include "EGISAPTrustlet.h"
@@ -19,11 +20,13 @@ using ::android::hardware::hidl_string;
 using ::android::hardware::hidl_vec;
 using ::android::hardware::Return;
 using ::android::hardware::Void;
+using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintAcquiredInfo;
+using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintError;
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprintClientCallback;
 using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
 
-struct BiometricsFingerprint : public IBiometricsFingerprint {
+struct BiometricsFingerprint : public IBiometricsFingerprint, public WorkHandler {
    public:
     BiometricsFingerprint(EgisFpDevice &&);
 
@@ -45,7 +48,22 @@ struct BiometricsFingerprint : public IBiometricsFingerprint {
     MasterKey mMasterKey;
     sp<IBiometricsFingerprintClientCallback> mClientCallback;
     std::mutex mClientCallbackMutex;
-    uint32_t mGid;
+    uint32_t mGid = -1;
+    WorkerThread mWt;
+
+    int mEnrollTimeout = -1;
+    uint32_t mNewPrintId = -1;
+    uint64_t mEnrollChallenge = 0;
+
+    // WorkHandler implementations:
+    void AuthenticateAsync();
+    void EnrollAsync();
+
+    void NotifyAcquired(FingerprintAcquiredInfo);
+    void NotifyAuthenticated(uint32_t fid, const hw_auth_token_t &hat);
+    void NotifyEnrollResult(uint32_t fid, uint32_t remaining);
+    void NotifyError(FingerprintError);
+    void NotifyRemove(uint32_t fid, uint32_t remaining);
 };
 
 }  // namespace egistec::ganges

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -8,6 +8,7 @@
 
 #include <egistec/EgisFpDevice.h>
 #include <array>
+#include "EGISAPTrustlet.h"
 #include "QSEEKeymasterTrustlet.h"
 
 namespace egistec::ganges {
@@ -39,6 +40,7 @@ struct BiometricsFingerprint : public IBiometricsFingerprint {
     Return<RequestStatus> authenticate(uint64_t operationId, uint32_t gid) override;
 
    private:
+    EGISAPTrustlet mTrustlet;
     EgisFpDevice mDev;
     MasterKey mMasterKey;
     sp<IBiometricsFingerprintClientCallback> mClientCallback;

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -58,8 +58,9 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public WorkHandler
     int64_t mOperationId;
 
     // WorkHandler implementations:
-    void AuthenticateAsync();
-    void EnrollAsync();
+    void AuthenticateAsync() override;
+    void EnrollAsync() override;
+    void OnEnterIdle() override;
 
     void NotifyAcquired(FingerprintAcquiredInfo);
     void NotifyAuthenticated(uint32_t fid, const hw_auth_token_t &hat);

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -55,6 +55,8 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public WorkHandler
     uint32_t mNewPrintId = -1;
     uint64_t mEnrollChallenge = 0;
 
+    int64_t mOperationId;
+
     // WorkHandler implementations:
     void AuthenticateAsync();
     void EnrollAsync();

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -1,0 +1,49 @@
+/**
+ * Fingerprint HAL implementation for Egistec sensors.
+ */
+
+#pragma once
+
+#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
+
+#include <egistec/EgisFpDevice.h>
+#include <array>
+#include "QSEEKeymasterTrustlet.h"
+
+namespace egistec::ganges {
+
+using ::android::sp;
+using ::android::hardware::hidl_array;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
+using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprintClientCallback;
+using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
+
+struct BiometricsFingerprint : public IBiometricsFingerprint {
+   public:
+    BiometricsFingerprint(EgisFpDevice &&);
+
+    // Methods from ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint follow.
+    Return<uint64_t> setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) override;
+    Return<uint64_t> preEnroll() override;
+    Return<RequestStatus> enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t timeoutSec) override;
+    Return<RequestStatus> postEnroll() override;
+    Return<uint64_t> getAuthenticatorId() override;
+    Return<RequestStatus> cancel() override;
+    Return<RequestStatus> enumerate() override;
+    Return<RequestStatus> remove(uint32_t gid, uint32_t fid) override;
+    Return<RequestStatus> setActiveGroup(uint32_t gid, const hidl_string &storePath) override;
+    Return<RequestStatus> authenticate(uint64_t operationId, uint32_t gid) override;
+
+   private:
+    EgisFpDevice mDev;
+    MasterKey mMasterKey;
+    sp<IBiometricsFingerprintClientCallback> mClientCallback;
+    std::mutex mClientCallbackMutex;
+    uint32_t mGid;
+};
+
+}  // namespace egistec::ganges

--- a/egistec/ganges/EGISAPTrustlet.cpp
+++ b/egistec/ganges/EGISAPTrustlet.cpp
@@ -298,6 +298,9 @@ int EGISAPTrustlet::Enroll(uint32_t gid, uint32_t fid, enroll_result_t &result) 
  * chosen id is available.
  */
 int EGISAPTrustlet::GetNewPrintId(uint32_t gid, uint32_t &new_print_id) {
+    // Use a seed other than the default 1:
+    srand(clock());
+
     std::vector<uint32_t> prints;
     int rc = GetPrintIds(gid, prints);
     if (rc)

--- a/egistec/ganges/EGISAPTrustlet.cpp
+++ b/egistec/ganges/EGISAPTrustlet.cpp
@@ -1,0 +1,184 @@
+#include "EGISAPTrustlet.h"
+#include <string.h>
+#include "FormatException.hpp"
+
+#define LOG_TAG "FPC ET"
+#define LOG_NDEBUG 0
+#include <log/log.h>
+
+namespace egistec::ganges {
+
+void log_hex(const char *data, int length) {
+    if (length <= 0 || data == NULL)
+        return;
+
+    // Trim leading nullsi, 4 bytes at a time:
+    int cnt = 0;
+    for (; length > 0 && !*(const uint32_t *)data; cnt++, data += 4, length -= 4)
+        ;
+
+    // Trim trailing nulls:
+    for (; length > 0 && !data[length - 1]; --length)
+        ;
+
+    if (length <= 0) {
+        ALOGV("All data is 0!");
+        return;
+    }
+
+    if (cnt)
+        ALOGV("Skipped %d integers (%d bytes)", cnt, cnt * 4);
+
+    // Format the byte-buffer into hexadecimals:
+    char *buf = (char *)malloc(length * 3 + 10);
+    char *base = buf;
+    for (int i = 0; i < length; i++) {
+        sprintf(buf, "%02X", data[i]);
+        buf += 2;
+        *buf++ = ' ';
+
+        if (i % 16 == 15 || i + 1 == length) {
+            *buf = '\0';
+            ALOGV("%s", base);
+            buf = base;
+        }
+    }
+
+    free(base);
+}
+
+EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet("egisap32", 0x2400) {
+}
+
+int EGISAPTrustlet::SendCommand(EGISAPTrustlet::API &lockedBuffer) {
+    // TODO: += !
+    lockedBuffer.GetRequest().process = 0xe0;
+
+    struct __attribute__((__packed__)) APIPrefix {
+        uint32_t process_id;
+        uint32_t no_extra_buffer;
+        uint32_t a;
+        uint32_t extra_buffer_size;
+        union {
+            uint64_t b;
+            struct {
+                uint32_t ret_val;
+            };
+        };
+        union {
+            uint64_t c;
+            struct {
+                uint32_t c2;
+                // TODO: Could be little-endian
+                uint8_t extra_flags;
+            };
+        };
+    };
+    static_assert(offsetof(APIPrefix, extra_buffer_size) == 0xc, "");
+    static_assert(offsetof(APIPrefix, b) == 0x10, "");
+    static_assert(offsetof(APIPrefix, ret_val) == 0x10, "");
+    static_assert(offsetof(APIPrefix, c) == 0x18, "");
+    static_assert(offsetof(APIPrefix, extra_flags) == 0x1c, "");
+    auto prefix = reinterpret_cast<APIPrefix *>(*lockedBuffer.mLockedBuffer);
+    // TODO: Replace with memset?
+    prefix->process_id = lockedBuffer.GetRequest().process;
+    prefix->b = 0;
+    prefix->c = 0;
+
+    prefix->no_extra_buffer = 0;
+    prefix->extra_buffer_size = 0;
+
+#if !LOG_NDEBUG
+    log_hex(reinterpret_cast<const char *>(&lockedBuffer.GetRequest()), sizeof(trustlet_buffer_t));
+#endif
+
+    int rc = QSEETrustlet::SendCommand(prefix, 0x880, prefix, 0x840);
+    if (rc) {
+        ALOGE("%s failed with rc = %d", __func__, rc);
+        return rc;
+    }
+
+#if !LOG_NDEBUG
+    ALOGV("Response:");
+    log_hex(reinterpret_cast<const char *>(&lockedBuffer.GetResponse()), sizeof(trustlet_buffer_t));
+#endif
+
+    // struct  __attribute__((__packed__)) APIResponse {
+    //     uint64_t padding[2];
+    //     uint32_t ret_val;
+    //     char data[];
+    // };
+
+    // TODO: List expected response codes in an enum.
+    rc = prefix->ret_val;
+    ALOGE_IF(rc, "%s ret_val = %#x", __func__, rc);
+    return rc;
+}
+
+int EGISAPTrustlet::SendCommand(EGISAPTrustlet::API &buffer, CommandId commandId, uint32_t gid) {
+    buffer.GetRequest().command = commandId;
+    buffer.GetRequest().gid = gid;
+    return SendCommand(buffer);
+}
+
+int EGISAPTrustlet::SendCommand(CommandId commandId, uint32_t gid) {
+    auto api = GetLockedAPI();
+    return SendCommand(api, commandId, gid);
+}
+
+int EGISAPTrustlet::SendDataCommand(EGISAPTrustlet::API &buffer, CommandId commandId, const void *data, size_t length, uint32_t gid) {
+    auto &req = buffer.GetRequest();
+    req.buffer_size = length;
+    memcpy(req.data, data, length);
+
+    return SendCommand(buffer, commandId, gid);
+}
+
+int EGISAPTrustlet::SendDataCommand(CommandId commandId, const void *data, size_t length, uint32_t gid) {
+    auto api = GetLockedAPI();
+    return SendDataCommand(api, commandId, data, length, gid);
+}
+
+/**
+ * Prepare buffer for use.
+ */
+EGISAPTrustlet::API EGISAPTrustlet::GetLockedAPI() {
+    auto lockedBuffer = GetLockedBuffer();
+    memset(*lockedBuffer, 0, EGISAPTrustlet::API::BufferSize());
+    return lockedBuffer;
+}
+
+int EGISAPTrustlet::Calibrate() {
+    return SendCommand(CommandId::Calibrate);
+}
+
+int EGISAPTrustlet::InitializeAlgo() {
+    return SendCommand(CommandId::InitializeAlgo);
+}
+
+int EGISAPTrustlet::InitializeSensor() {
+    return SendCommand(CommandId::InitializeSensor);
+}
+
+int EGISAPTrustlet::SetDataPath(const char *data_path) {
+    return SendDataCommand(CommandId::SetDataPath, data_path, strlen(data_path), 1);
+}
+
+int EGISAPTrustlet::SetMasterKey(const MasterKey &key) {
+    return SendDataCommand(CommandId::SetMasterKey, key.data(), key.size());
+}
+
+int EGISAPTrustlet::SetUserDataPath(uint32_t gid, const char *data_path) {
+    return SendDataCommand(CommandId::SetUserDataPath, data_path, strlen(data_path), gid);
+}
+
+int EGISAPTrustlet::SetWorkMode(uint32_t workMode) {
+    // WARNING: Work mode is passed in through gid!
+    return SendCommand(CommandId::SetWorkMode, workMode);
+}
+
+uint64_t EGISAPTrustlet::GetAuthenticatorId() {
+    return -1;
+}
+
+}  // namespace egistec::ganges

--- a/egistec/ganges/EGISAPTrustlet.cpp
+++ b/egistec/ganges/EGISAPTrustlet.cpp
@@ -338,4 +338,10 @@ int EGISAPTrustlet::FinalizeEnroll() {
     return SendCommand(CommandId::FinalizeEnroll);
 }
 
+int EGISAPTrustlet::RemovePrint(uint32_t gid, uint32_t fid) {
+    auto api = GetLockedAPI();
+    api.GetRequest().fid = fid;
+    return SendCommand(api, CommandId::RemovePrint, gid);
+}
+
 }  // namespace egistec::ganges

--- a/egistec/ganges/EGISAPTrustlet.h
+++ b/egistec/ganges/EGISAPTrustlet.h
@@ -17,7 +17,14 @@ enum class CommandId : uint32_t {
     InitializeSensor = 2,
     Calibrate = 6,
 
-    GetImage = 0x8,
+    GetImage = 8,
+    GetEnrolledCount = 9,
+
+    InitializeIdentify = 0xf,
+    Identify = 0x10,
+    FinalizeIdentify = 0x11,
+    UpdateTemplate = 0x12,
+    SaveTemplate = 0x13,
 
     InitializeEnroll = 0xb,
     Enroll = 0xc,
@@ -47,7 +54,9 @@ enum class ImageResult : uint32_t {
     Lost = 6,
     ImagerDirty = 7,
     Partial = 8,
+    ImagerDirty9 = 9,
     Nothing = 10,
+    Mediocre = 0xc,
     DirtOnSensor = 0xd,
 };
 
@@ -99,6 +108,24 @@ typedef struct {
 } enroll_result_t;
 
 static_assert(sizeof(enroll_result_t) == 0x20, "");
+
+typedef struct {
+    uint32_t match_id;
+    uint32_t status;
+    uint32_t set_to_1;
+    uint32_t returned_size;
+    uint32_t template_cnt;
+    uint32_t capture_time;
+    uint32_t identify_time;
+    uint32_t score;
+    uint32_t index;
+    uint32_t learn_update;
+    uint32_t noidea;
+    uint32_t cov;
+    uint32_t quality;
+    uint32_t sensor_hwid;
+    hw_auth_token_t hat;
+} identify_result_t;
 
 class EGISAPTrustlet : public QSEETrustlet {
    protected:
@@ -181,6 +208,13 @@ class EGISAPTrustlet : public QSEETrustlet {
     int FinalizeEnroll();
 
     int RemovePrint(uint32_t gid, uint32_t fid);
+
+    int FinalizeIdentify();
+    int GetEnrolledCount(uint32_t &);
+    int Identify(uint32_t gid, uint64_t opid, identify_result_t &);
+    int InitializeIdentify();
+    int SaveTemplate();
+    int UpdateTemplate(bool &updated);
 };
 
 }  // namespace egistec::ganges

--- a/egistec/ganges/EGISAPTrustlet.h
+++ b/egistec/ganges/EGISAPTrustlet.h
@@ -24,6 +24,7 @@ enum class CommandId : uint32_t {
     FinalizeEnroll = 0xd,
     SaveEnrolledPrint = 0xe,
 
+    RemovePrint = 0x15,
     GetPrintIds = 0x16,
     SetWorkMode = 0x17,
     SetUserDataPath = 0x18,
@@ -178,6 +179,8 @@ class EGISAPTrustlet : public QSEETrustlet {
     int InitializeEnroll();
     int SaveEnrolledPrint(uint32_t gid, uint64_t fid);
     int FinalizeEnroll();
+
+    int RemovePrint(uint32_t gid, uint32_t fid);
 };
 
 }  // namespace egistec::ganges

--- a/egistec/ganges/EGISAPTrustlet.h
+++ b/egistec/ganges/EGISAPTrustlet.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <arpa/inet.h>
+#include <hardware/hw_auth_token.h>
+#include <string.h>
+#include <algorithm>
+#include <vector>
+#include "QSEEKeymasterTrustlet.h"
+#include "QSEETrustlet.h"
+
+namespace egistec::ganges {
+
+enum class CommandId : uint32_t {
+    SetMasterKey = 0,
+    InitializeAlgo = 1,
+    InitializeSensor = 2,
+    Calibrate = 6,
+
+    GetPrintIds = 0x16,
+    SetWorkMode = 0x17,
+    SetUserDataPath = 0x19,
+    SetDataPath = 0x19,
+    GetAuthenticatorId = 0x20,
+};
+
+/**
+ * The datastructure through which this userspace HAL communicates with the TZ app.
+ */
+typedef struct {
+    uint32_t process;
+    CommandId command;
+    uint32_t gid;
+    uint32_t fid;
+    uint32_t buffer_size;
+    char data[];
+} trustlet_buffer_t;
+
+static_assert(sizeof(trustlet_buffer_t) == 0x14, "trustlet_buffer_t not of expected size!");
+
+class EGISAPTrustlet : public QSEETrustlet {
+   protected:
+    class API {
+        // TODO: Could be a templated class defined in QSEETrustlet.
+
+        static inline constexpr auto RequestOffset = 0x5c;
+        static inline constexpr auto ResponseOffset = 0x14;
+
+        QSEETrustlet::LockedIONBuffer mLockedBuffer;
+
+       public:
+        inline API(QSEETrustlet::LockedIONBuffer &&lockedBuffer) : mLockedBuffer(std::move(lockedBuffer)) {
+        }
+
+        inline trustlet_buffer_t &GetRequest() {
+            return *reinterpret_cast<trustlet_buffer_t *>((ptrdiff_t)*mLockedBuffer + RequestOffset);
+        }
+
+        inline trustlet_buffer_t &GetResponse() {
+            return *reinterpret_cast<trustlet_buffer_t *>((ptrdiff_t)*mLockedBuffer + ResponseOffset);
+        }
+
+        inline void MoveResponseToRequest() {
+            memmove(&GetRequest(), &GetResponse(), sizeof(trustlet_buffer_t));
+        }
+
+        static inline constexpr size_t BufferSize() {
+            return sizeof(trustlet_buffer_t) + std::max(RequestOffset, ResponseOffset);
+        }
+
+        friend class EGISAPTrustlet;
+    };
+
+   public:
+    EGISAPTrustlet();
+
+    int SendCommand(API &);
+    int SendCommand(API &, CommandId, uint32_t gid = 0);
+    int SendCommand(CommandId, uint32_t gid = 0);
+    int SendDataCommand(API &, CommandId, const void *data, size_t length, uint32_t gid = 0);
+    int SendDataCommand(CommandId, const void *data, size_t length, uint32_t gid = 0);
+    API GetLockedAPI();
+
+    int Calibrate();
+    int InitializeAlgo();
+    int InitializeSensor();
+    int SetDataPath(const char *);
+    int SetMasterKey(const MasterKey &);
+    int SetUserDataPath(uint32_t gid, const char *);
+    int SetWorkMode(uint32_t);
+    uint64_t GetAuthenticatorId();
+};
+
+}  // namespace egistec::ganges

--- a/egistec/nile/BiometricsFingerprint.cpp
+++ b/egistec/nile/BiometricsFingerprint.cpp
@@ -1,17 +1,12 @@
-#include "BiometricsFingerprint_efp.h"
-#include "FormatException.hpp"
+#include <FormatException.hpp>
+#include "BiometricsFingerprint.h"
 
 #define LOG_TAG "FPC ET"
 #include <log/log.h>
 
-namespace android {
-namespace hardware {
-namespace biometrics {
-namespace fingerprint {
-namespace V2_1 {
-namespace implementation {
+namespace egistec::nile {
 
-BiometricsFingerprint_efp::BiometricsFingerprint_efp(EgisFpDevice &&dev) : loops(reinterpret_cast<uint64_t>(this), std::move(dev)) {
+BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : loops(reinterpret_cast<uint64_t>(this), std::move(dev)) {
     QSEEKeymasterTrustlet keymaster;
     mMasterKey = keymaster.GetKey();
 
@@ -24,7 +19,7 @@ BiometricsFingerprint_efp::BiometricsFingerprint_efp(EgisFpDevice &&dev) : loops
         throw FormatException("SetMasterKey failed with rc = %d", rc);
 }
 
-Return<uint64_t> BiometricsFingerprint_efp::setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) {
+Return<uint64_t> BiometricsFingerprint::setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) {
     loops.SetNotify(clientCallback);
     // This is here because HAL 2.1 doesn't have a way to propagate a
     // unique token for its driver. Subsequent versions should send a unique
@@ -33,14 +28,14 @@ Return<uint64_t> BiometricsFingerprint_efp::setNotify(const sp<IBiometricsFinger
     return reinterpret_cast<uint64_t>(this);
 }
 
-Return<uint64_t> BiometricsFingerprint_efp::preEnroll() {
+Return<uint64_t> BiometricsFingerprint::preEnroll() {
     // TODO: Original service aborts+retries on failure.
     auto challenge = loops.GetChallenge();
     ALOGI("%s: Generated enroll challenge %#lx", __func__, challenge);
     return challenge;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t timeoutSec) {
+Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t timeoutSec) {
     if (gid != mGid) {
         ALOGE("Cannot enroll finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
         return RequestStatus::SYS_EINVAL;
@@ -58,27 +53,27 @@ Return<RequestStatus> BiometricsFingerprint_efp::enroll(const hidl_array<uint8_t
     return loops.Enroll(*h, timeoutSec) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::postEnroll() {
+Return<RequestStatus> BiometricsFingerprint::postEnroll() {
     ALOGI("%s: clearing challenge", __func__);
     // TODO: Original service aborts+retries on failure.
     return loops.ClearChallenge() ? RequestStatus::SYS_UNKNOWN : RequestStatus::SYS_OK;
 }
 
-Return<uint64_t> BiometricsFingerprint_efp::getAuthenticatorId() {
+Return<uint64_t> BiometricsFingerprint::getAuthenticatorId() {
     return loops.GetAuthenticatorId();
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::cancel() {
+Return<RequestStatus> BiometricsFingerprint::cancel() {
     ALOGI("Cancel requested");
     bool success = loops.Cancel();
     return success ? RequestStatus::SYS_OK : RequestStatus::SYS_UNKNOWN;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::enumerate() {
+Return<RequestStatus> BiometricsFingerprint::enumerate() {
     return loops.Enumerate() ? RequestStatus::SYS_UNKNOWN : RequestStatus::SYS_OK;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::remove(uint32_t gid, uint32_t fid) {
+Return<RequestStatus> BiometricsFingerprint::remove(uint32_t gid, uint32_t fid) {
     ALOGI("%s: gid = %d, fid = %d", __func__, gid, fid);
     if (gid != mGid) {
         ALOGE("Change group and userpath through setActiveGroup first!");
@@ -87,14 +82,14 @@ Return<RequestStatus> BiometricsFingerprint_efp::remove(uint32_t gid, uint32_t f
     return loops.RemoveFinger(fid) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::setActiveGroup(uint32_t gid, const hidl_string &storePath) {
+Return<RequestStatus> BiometricsFingerprint::setActiveGroup(uint32_t gid, const hidl_string &storePath) {
     ALOGI("%s: gid = %u, path = %s", __func__, gid, storePath.c_str());
     mGid = gid;
     int rc = loops.SetUserDataPath(mGid, storePath.c_str());
     return rc ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
-Return<RequestStatus> BiometricsFingerprint_efp::authenticate(uint64_t operationId, uint32_t gid) {
+Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operationId, uint32_t gid) {
     ALOGI("%s: gid = %d, secret = %lu", __func__, gid, operationId);
     if (gid != mGid) {
         ALOGE("Cannot authenticate finger for different gid! Caller needs to update storePath first with setActiveGroup()!");
@@ -104,9 +99,4 @@ Return<RequestStatus> BiometricsFingerprint_efp::authenticate(uint64_t operation
     return loops.Authenticate(operationId) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
-}  // namespace implementation
-}  // namespace V2_1
-}  // namespace fingerprint
-}  // namespace biometrics
-}  // namespace hardware
-}  // namespace android
+}  // namespace egistec::nile

--- a/egistec/nile/BiometricsFingerprint.h
+++ b/egistec/nile/BiometricsFingerprint.h
@@ -6,18 +6,14 @@
 
 #include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
 
+#include <QSEEKeymasterTrustlet.h>
 #include <array>
 #include "EgisOperationLoops.h"
-#include "QSEEKeymasterTrustlet.h"
 
-namespace android {
-namespace hardware {
-namespace biometrics {
-namespace fingerprint {
-namespace V2_1 {
-namespace implementation {
+namespace egistec::nile {
 
 using ::android::sp;
+using ::android::hardware::hidl_array;
 using ::android::hardware::hidl_string;
 using ::android::hardware::hidl_vec;
 using ::android::hardware::Return;
@@ -26,9 +22,9 @@ using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprintClientCallback;
 using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
 
-struct BiometricsFingerprint_efp : public IBiometricsFingerprint {
+struct BiometricsFingerprint : public IBiometricsFingerprint {
    public:
-    BiometricsFingerprint_efp(EgisFpDevice &&);
+    BiometricsFingerprint(EgisFpDevice &&);
 
     // Methods from ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint follow.
     Return<uint64_t> setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) override;
@@ -48,9 +44,4 @@ struct BiometricsFingerprint_efp : public IBiometricsFingerprint {
     EgisOperationLoops loops;
 };
 
-}  // namespace implementation
-}  // namespace V2_1
-}  // namespace fingerprint
-}  // namespace biometrics
-}  // namespace hardware
-}  // namespace android
+}  // namespace egistec::nile

--- a/egistec/nile/EGISAPTrustlet.cpp
+++ b/egistec/nile/EGISAPTrustlet.cpp
@@ -259,7 +259,7 @@ int EGISAPTrustlet::GetFingerList(std::vector<uint32_t> &list) {
     if (rc)
         return rc;
     list.clear();
-    list.resize(extraIn.number_of_prints);
+    list.reserve(extraIn.number_of_prints);
     ALOGD("GetFingerList reported %d fingers", extraOut.number_of_prints);
     std::copy(extraOut.finger_list, extraOut.finger_list + extraOut.number_of_prints, std::back_inserter(list));
     return 0;

--- a/egistec/nile/EGISAPTrustlet.cpp
+++ b/egistec/nile/EGISAPTrustlet.cpp
@@ -6,6 +6,8 @@
 // #define LOG_NDEBUG 0
 #include <log/log.h>
 
+namespace egistec::nile {
+
 void log_hex(const char *data, int length) {
     if (length <= 0 || data == NULL)
         return;
@@ -304,3 +306,5 @@ int EGISAPTrustlet::SetMasterKey(const MasterKey &key) {
 
     return SendExtraCommand(lockedBuffer, ExtraCommand::SetMasterKey);
 }
+
+}  // namespace egistec::nile

--- a/egistec/nile/EGISAPTrustlet.h
+++ b/egistec/nile/EGISAPTrustlet.h
@@ -8,6 +8,8 @@
 #include "QSEEKeymasterTrustlet.h"
 #include "QSEETrustlet.h"
 
+namespace egistec::nile {
+
 typedef struct {
     int qty;
     int corner_count;
@@ -343,3 +345,5 @@ class EGISAPTrustlet : public QSEETrustlet {
     int ClearChallenge();
     int SetMasterKey(const MasterKey &);
 };
+
+}  // namespace egistec::nile

--- a/egistec/nile/EgisOperationLoops.cpp
+++ b/egistec/nile/EgisOperationLoops.cpp
@@ -17,6 +17,8 @@
 #define LOG_NDEBUG 0
 #include <log/log.h>
 
+namespace egistec::nile {
+
 using ::android::hardware::hidl_vec;
 
 EgisOperationLoops::EgisOperationLoops(uint64_t deviceId, EgisFpDevice &&dev) : mDeviceId(deviceId), mDev(std::move(dev)), mAuthenticatorId(GetRand64()) {
@@ -760,3 +762,5 @@ error:
     NotifyError(FingerprintError::ERROR_UNABLE_TO_PROCESS);
     return rc;
 }
+
+}  // namespace egistec::nile

--- a/egistec/nile/EgisOperationLoops.cpp
+++ b/egistec/nile/EgisOperationLoops.cpp
@@ -442,7 +442,7 @@ void EgisOperationLoops::AuthenticateAsync() {
           result.template_cnt,
           result.capture_time,
           result.identify_time);
-    ALOGD("hmac timestamp: %ld secure_user_id: %ld ", result.hmac_timestamp, result.secure_user_id);
+    ALOGD("hmac timestamp: %lu secure_user_id: %lu ", result.hmac_timestamp, result.secure_user_id);
 
     // Finalize challenge buffer by filling in the cryptographic response:
     mCurrentChallenge.timestamp = result.hmac_timestamp;

--- a/egistec/nile/EgisOperationLoops.cpp
+++ b/egistec/nile/EgisOperationLoops.cpp
@@ -21,75 +21,7 @@ namespace egistec::nile {
 
 using ::android::hardware::hidl_vec;
 
-EgisOperationLoops::EgisOperationLoops(uint64_t deviceId, EgisFpDevice &&dev) : mDeviceId(deviceId), mDev(std::move(dev)), mAuthenticatorId(GetRand64()) {
-    event_fd = eventfd((eventfd_t)AsyncState::Idle, EFD_NONBLOCK);
-    if (event_fd < 0)
-        throw FormatException("Failed to create eventfd: %s", strerror(errno));
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd < 0)
-        throw FormatException("Failed to create epoll: %s", strerror(errno));
-
-    struct epoll_event ev = {
-        .data.fd = event_fd,
-        .events = EPOLLIN,
-    };
-    int rc = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, event_fd, &ev);
-    if (rc)
-        throw FormatException("Failed to add eventfd to epoll: %s", strerror(errno));
-    ev = {
-        .data.fd = mDev.GetDescriptor(),
-        .events = EPOLLIN,
-    };
-    rc = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, ev.data.fd, &ev);
-    if (rc)
-        throw FormatException("Failed to add eventfd to epoll: %s", strerror(errno));
-
-    rc = pthread_create(&thread, NULL, ThreadStart, this);
-    if (rc)
-        throw FormatException("Failed to start pthread: %d %s", rc, strerror(errno));
-}
-
-void *EgisOperationLoops::ThreadStart(void *arg) {
-    auto instance = static_cast<EgisOperationLoops *>(arg);
-    instance->RunThread();
-    return nullptr;
-}
-
-void EgisOperationLoops::RunThread() {
-    ALOGD("Async thread up");
-    for (;;) {
-        // NOTE: Not using WaitForEvent() here, because we are not interested
-        // in wakeups from the fp device, only in events.
-        struct pollfd pfd = {
-            .fd = event_fd,
-            .events = POLLIN,
-        };
-        int cnt = poll(&pfd, 1, -1);
-        if (cnt <= 0) {
-            ALOGW("Infinite poll returned with %d", cnt);
-            continue;
-        }
-
-        auto nextState = ReadState();
-        currentState = nextState;
-        switch (nextState) {
-            case AsyncState::Idle:
-                ALOGW("Unexpected AsyncState %lu", nextState);
-                break;
-            case AsyncState::Cancel:
-                // Nothing in progress - still notify that the current operation was cancelled.
-                ALOGW("Unexpected AsyncState::Cancel - nothing in progress");
-                NotifyError(FingerprintError::ERROR_CANCELED);
-                break;
-            case AsyncState::Authenticating:
-                AuthenticateAsync();
-                break;
-            case AsyncState::Enrolling:
-                EnrollAsync();
-                break;
-        }
-        currentState = AsyncState::Idle;
-    }
+EgisOperationLoops::EgisOperationLoops(uint64_t deviceId, EgisFpDevice &&dev) : mDeviceId(deviceId), mDev(std::move(dev)), mAuthenticatorId(GetRand64()), mWt(this, mDev.GetFd()) {
 }
 
 void EgisOperationLoops::ProcessOpcode(const command_buffer_t &cmd) {
@@ -147,83 +79,9 @@ bool EgisOperationLoops::ConvertAndCheckError(int &rc, EGISAPTrustlet::API &lock
     return true;
 }
 
-EgisOperationLoops::WakeupReason EgisOperationLoops::WaitForEvent(int timeoutSec) {
-    constexpr auto EVENT_COUNT = 2;
-    struct epoll_event events[EVENT_COUNT];
-    ALOGD("%s: TimeoutSec = %d", __func__, timeoutSec);
-    int cnt = epoll_wait(epoll_fd, events, EVENT_COUNT, 1000 * timeoutSec);
-
-    if (cnt < 0) {
-        ALOGE("%s: epoll_wait failed: %s", __func__, strerror(errno));
-        // Let the current operation continue as if nothing happened:
-        return WakeupReason::Timeout;
-    }
-
-    if (!cnt) {
-        ALOGD("%s: WakeupReason = Timeout", __func__);
-        return WakeupReason::Timeout;
-    }
-
-    // Control events have priority over finger events, since
-    // this is probably a request to cancel the current operation.
-    for (auto ei = 0; ei < cnt; ++ei)
-        if (events[ei].data.fd == event_fd && events[ei].events & EPOLLIN) {
-            ALOGD("%s: WakeupReason = Event", __func__);
-            return WakeupReason::Event;
-        }
-
-    for (auto ei = 0; ei < cnt; ++ei)
-        if (events[ei].data.fd == mDev.GetDescriptor() && events[ei].events & EPOLLIN) {
-            ALOGD("%s: WakeupReason = Finger", __func__);
-            return WakeupReason::Finger;
-        }
-
-    throw FormatException("Invalid fd source!");
-}
-
-bool EgisOperationLoops::MoveToState(AsyncState nextState) {
-    ALOGD("Attempting to move to state %lu", nextState);
-    // TODO: This is racy (eg. does not look at in-flight state),
-    // but it does not matter because async operations are not supposed to be
-    // invoked concurrently (how can a device run any combination of authenticate or
-    // enroll simultaneously??). The thread will simply reject it in that case.
-
-    // Currently, the service that uses this HAL (FingerprintService.java) calls cancel() in
-    // such a case, and only starts the next operation upon receiving FingerprintError::ERROR_CANCELED.
-
-    if (nextState != AsyncState::Cancel && currentState != AsyncState::Idle) {
-        ALOGW("Thread already in state %lu, refusing to move to %lu", currentState, nextState);
-        return false;
-    }
-
-    int rc = eventfd_write(event_fd, (eventfd_t)nextState);
-    if (rc) {
-        ALOGE("Failed to write next state to eventfd: %s", strerror(errno));
-        return false;
-    }
-    return true;
-}
-
-EgisOperationLoops::AsyncState EgisOperationLoops::ReadState() {
-    eventfd_t requestedState;
-    int rc = eventfd_read(event_fd, &requestedState);
-    if (rc) {
-        // This is very common when no state is available (read returns 0 bytes when the state is 0).
-        // ALOGE("Failed to read next state from eventfd: %s", strerror(errno));
-        return AsyncState::Idle;
-    }
-    return static_cast<AsyncState>(requestedState);
-}
-
 bool EgisOperationLoops::CheckAndHandleCancel(EGISAPTrustlet::API &lockedBuffer) {
-    auto requestedState = static_cast<eventfd_t>(ReadState());
-    if (requestedState & ~static_cast<eventfd_t>(AsyncState::Cancel))
-        // The call to eventfd_read consumed an (unexpected and incorrect)
-        // state change; warn if that happens.
-        ALOGW("%s: Ignoring requested state %lu", __func__, requestedState);
-
-    auto cancelled = requestedState & static_cast<eventfd_t>(AsyncState::Cancel);
-    ALOGV("%s: %lu", __func__, cancelled);
+    auto cancelled = mWt.IsCanceled();
+    ALOGV("%s: %d", __func__, cancelled);
     if (cancelled)
         RunCancel(lockedBuffer);
     return cancelled;
@@ -333,7 +191,7 @@ void EgisOperationLoops::NotifyBadImage(int reason) {
 FingerprintError EgisOperationLoops::HandleMainStep(command_buffer_t &cmd, int timeoutSec) {
     switch (cmd.step) {
         case Step::WaitFingerprint: {
-            auto reason = WaitForEvent(timeoutSec);
+            auto reason = mWt.WaitForEvent(timeoutSec);
             switch (reason) {
                 case WakeupReason::Timeout:
                     // Return timeout: this notifies the service and stops the current loop.
@@ -673,7 +531,7 @@ int EgisOperationLoops::Prepare() {
 bool EgisOperationLoops::Cancel() {
     ALOGI("Requesting thread to cancel current operation...");
     // Always let the thread handle cancel requests to prevent concurrency issues.
-    return MoveToState(AsyncState::Cancel);
+    return mWt.MoveToState(AsyncState::Cancel);
 }
 
 int EgisOperationLoops::Enumerate() {
@@ -728,7 +586,7 @@ int EgisOperationLoops::Enroll(const hw_auth_token_t &hat, uint32_t timeoutSec) 
         goto error;
     }
 
-    rc = !MoveToState(AsyncState::Enrolling);
+    rc = !mWt.MoveToState(AsyncState::Enroll);
     if (!rc)
         return 0;
 
@@ -753,7 +611,7 @@ int EgisOperationLoops::Authenticate(uint64_t challenge) {
         goto error;
     }
 
-    rc = !MoveToState(AsyncState::Authenticating);
+    rc = !mWt.MoveToState(AsyncState::Authenticate);
     if (!rc)
         return 0;
 

--- a/egistec/nile/EgisOperationLoops.h
+++ b/egistec/nile/EgisOperationLoops.h
@@ -73,8 +73,8 @@ class EgisOperationLoops : public EGISAPTrustlet, public WorkHandler {
 
     // WorkHandler implementations:
     // These should run asynchronously from HAL calls:
-    void EnrollAsync();
-    void AuthenticateAsync();
+    void EnrollAsync() override;
+    void AuthenticateAsync() override;
 
    public:
     uint64_t GetAuthenticatorId();

--- a/egistec/nile/EgisOperationLoops.h
+++ b/egistec/nile/EgisOperationLoops.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <WorkerThread.h>
 #include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprintClientCallback.h>
 #include <egistec/EgisFpDevice.h>
 #include <sys/eventfd.h>
@@ -17,38 +18,19 @@ using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint
  * External wrapper class containing TZ communication logic
  * (Separated from datastructural/architectural choices).
  */
-class EgisOperationLoops : public EGISAPTrustlet {
-    enum class AsyncState : eventfd_t {
-        Idle = 0,
-        Cancel = 1,
-        Authenticating = 2,
-        Enrolling = 4,
-    };
-
-    enum class WakeupReason {
-        Timeout,
-        Event,
-        Finger,  // Hardware
-    };
-
+class EgisOperationLoops : public EGISAPTrustlet, public WorkHandler {
     const uint64_t mDeviceId;
-    uint32_t mGid;
+    EgisFpDevice mDev;
     sp<IBiometricsFingerprintClientCallback> mClientCallback;
     std::mutex mClientCallbackMutex;
-    EgisFpDevice mDev;
+    uint32_t mGid;
     uint64_t mAuthenticatorId;
-
-    AsyncState currentState = AsyncState::Idle;
-    int epoll_fd;
-    int event_fd;
-    pthread_t thread;
+    WorkerThread mWt;
 
    public:
     EgisOperationLoops(uint64_t deviceId, EgisFpDevice &&);
 
    private:
-    static void *ThreadStart(void *);
-    void RunThread();
     void ProcessOpcode(const command_buffer_t &);
     int ConvertReturnCode(int);
     /**
@@ -57,9 +39,6 @@ class EgisOperationLoops : public EGISAPTrustlet {
      * @return True when an error occured.
      */
     bool ConvertAndCheckError(int &, EGISAPTrustlet::API &);
-    WakeupReason WaitForEvent(int timeoutSec = -1);
-    bool MoveToState(AsyncState);
-    AsyncState ReadState();
     /**
      * Atomically check if the current operation is requested to cancel.
      * If cancelled, TZ cancel will be invoked and the service will be
@@ -92,6 +71,7 @@ class EgisOperationLoops : public EGISAPTrustlet {
      */
     FingerprintError HandleMainStep(command_buffer_t &, int timeoutSec = -1);
 
+    // WorkHandler implementations:
     // These should run asynchronously from HAL calls:
     void EnrollAsync();
     void AuthenticateAsync();

--- a/egistec/nile/EgisOperationLoops.h
+++ b/egistec/nile/EgisOperationLoops.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprintClientCallback.h>
+#include <egistec/EgisFpDevice.h>
 #include <sys/eventfd.h>
 #include <mutex>
 #include "EGISAPTrustlet.h"
-#include "EgisFpDevice.h"
+
+namespace egistec::nile {
 
 using ::android::sp;
 using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintAcquiredInfo;
@@ -106,3 +108,5 @@ class EgisOperationLoops : public EGISAPTrustlet {
     int Enroll(const hw_auth_token_t &, uint32_t timeoutSec);
     int Authenticate(uint64_t challenge);
 };
+
+}  // namespace egistec::nile

--- a/service.cpp
+++ b/service.cpp
@@ -29,7 +29,7 @@ using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 using android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
 
-using FPCHAL = android::hardware::biometrics::fingerprint::V2_1::implementation::BiometricsFingerprint;
+using FPCHAL = ::fpc::BiometricsFingerprint;
 using NileHAL = ::egistec::nile::BiometricsFingerprint;
 using GangesHAL = ::egistec::ganges::BiometricsFingerprint;
 


### PR DESCRIPTION
Ganges uses a completely different command structure than Nile, despite utilizing a similar sensor.

This PR restructures some of the original code, and adds everything necessary to support the sensors found in Ganges devices.

Tested on Pie:
- Discovery
- Mermaid
- Akatsuki

Build-tested on Oreo for a ganges/nile/tama configuration: no issues.