### PR TITLE
[1/2] Revert horrible workaround for ET51x sensor; patch up previous PR

### DIFF
--- a/WorkerThread.h
+++ b/WorkerThread.h
@@ -8,6 +8,7 @@ enum class AsyncState : eventfd_t {
     Cancel,
     Authenticate,
     Enroll,
+    Stop,
 };
 
 enum class WakeupReason {
@@ -39,6 +40,9 @@ class WorkerThread {
 
    public:
     WorkerThread(WorkHandler *handler, int dev_fd);
+
+    void Start();
+    void Stop();
 
     AsyncState ReadState();
     bool IsCanceled();

--- a/android.hardware.biometrics.fingerprint@2.1-service.sony.rc
+++ b/android.hardware.biometrics.fingerprint@2.1-service.sony.rc
@@ -5,8 +5,3 @@ service fps_hal /vendor/bin/hw/android.hardware.biometrics.fingerprint@2.1-servi
     class late_start
     user system
     group system input
-
-    # This is a horrible workaround for the stuck TZ application and should be fixed ASAP
-on property:sys.boot_completed=1 && property:ro.board.platform=sdm660
-    stop fps_hal
-    start fps_hal

--- a/egistec/ganges/BiometricsFingerprint.h
+++ b/egistec/ganges/BiometricsFingerprint.h
@@ -29,6 +29,7 @@ using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
 struct BiometricsFingerprint : public IBiometricsFingerprint, public WorkHandler {
    public:
     BiometricsFingerprint(EgisFpDevice &&);
+    ~BiometricsFingerprint();
 
     // Methods from ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint follow.
     Return<uint64_t> setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) override;

--- a/egistec/ganges/EGISAPTrustlet.cpp
+++ b/egistec/ganges/EGISAPTrustlet.cpp
@@ -222,6 +222,18 @@ int EGISAPTrustlet::SetWorkMode(uint32_t workMode) {
     return SendCommand(CommandId::SetWorkMode, workMode);
 }
 
+int EGISAPTrustlet::UninitializeAlgo() {
+    return SendCommand(CommandId::UninitializeAlgo);
+}
+
+int EGISAPTrustlet::UninitializeSdk() {
+    return SendCommand(CommandId::UninitializeSdk);
+}
+
+int EGISAPTrustlet::UninitializeSensor() {
+    return SendCommand(CommandId::UninitializeSensor);
+}
+
 uint64_t EGISAPTrustlet::GetAuthenticatorId() {
     TypedIonBuffer<uint64_t> id;
     auto api = GetLockedAPI();
@@ -235,8 +247,6 @@ uint64_t EGISAPTrustlet::GetAuthenticatorId() {
              __func__);
     if (api.Base().extra_buffer_size != sizeof(uint64_t))
         return -1;
-
-    ALOGI("%s: id=%#lx", __func__, *id);
 
     return *id;
 }

--- a/egistec/ganges/EGISAPTrustlet.h
+++ b/egistec/ganges/EGISAPTrustlet.h
@@ -15,6 +15,9 @@ enum class CommandId : uint32_t {
     SetMasterKey = 0,
     InitializeAlgo = 1,
     InitializeSensor = 2,
+    UninitializeSdk = 3,
+    UninitializeAlgo = 4,
+    UninitializeSensor = 5,
     Calibrate = 6,
 
     GetImage = 8,
@@ -192,6 +195,10 @@ class EGISAPTrustlet : public QSEETrustlet {
     int SetMasterKey(const MasterKey &);
     int SetUserDataPath(uint32_t gid, const char *);
     int SetWorkMode(uint32_t);
+    int UninitializeAlgo();
+    int UninitializeSdk();
+    int UninitializeSensor();
+
     uint64_t GetAuthenticatorId();
 
     int GetImage(ImageResult &quality);

--- a/egistec/nile/EgisOperationLoops.cpp
+++ b/egistec/nile/EgisOperationLoops.cpp
@@ -22,6 +22,7 @@ namespace egistec::nile {
 using ::android::hardware::hidl_vec;
 
 EgisOperationLoops::EgisOperationLoops(uint64_t deviceId, EgisFpDevice &&dev) : mDeviceId(deviceId), mDev(std::move(dev)), mAuthenticatorId(GetRand64()), mWt(this, mDev.GetFd()) {
+    mWt.Start();
 }
 
 void EgisOperationLoops::ProcessOpcode(const command_buffer_t &cmd) {


### PR DESCRIPTION
This workaround was necessary for an incorrectly rigged `poll_wait`.
Before this HAL initializes the GPIO is in the trigger (low) state which
made the poll fops handler bail out early without registering itself
through `poll_wait`. Future poll attempts from the HAL were not
accounted for properly, causing it to wait indefinitely.

After restarting the poll fops handler was invoked again, apparently
without ever bailing out early again. The same holds for FPC sensors,
which have a very similar driver.

Tested on:
SoMC Nile Discovery RoW with Egistec sensor
SoMC Ganges Mermaid RoW