### PR TITLE
[master] Android.mk: Add PRODUCT_PLATFORM_SOD build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,4 @@
+ifeq ($(PRODUCT_PLATFORM_SOD),true)
 ifneq ($(TARGET_DEVICE_NO_FPC), true)
 LOCAL_PATH := $(call my-dir)
 
@@ -68,3 +69,4 @@ LOCAL_CFLAGS += \
 
 include $(BUILD_EXECUTABLE)
 endif
+endif # PRODUCT_PLATFORM_SOD


### PR DESCRIPTION
Fingerprint HAL may be mistakenly included in other non-Sony
projects. To avoid this guard it using PRODUCT_PLATFORM_SOD
flag from other projects.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>