### PR TITLE
Egistec: Ganges: Fix integer division.

### DIFF
--- a/egistec/ganges/BiometricsFingerprint.cpp
+++ b/egistec/ganges/BiometricsFingerprint.cpp
@@ -537,7 +537,7 @@ void BiometricsFingerprint::EnrollAsync() {
                         steps_needed = 10;
                         if (percentage_done > 0)
                             // Calculate required number of steps based on reported percentage (without floats):
-                            steps_needed = 100 * steps_done / percentage_done;
+                            steps_needed = (100 * steps_done + percentage_done - 1) / percentage_done;
 
                         // Delay the final notify until after we have saved the fingerprint, otherwise
                         // there might be a race with postEnroll


### PR DESCRIPTION
Always round up in integer division to calculate the steps needed.
Otherwise e.g. steps_done = 5, percentage_done = 99 would result in
steps_needed = 5 and thus in samples_remaining = steps_needed - steps_done = 0
In this case the UI would think enrolling is done and might call postEnroll
and otherwise proceed even though one press on the fingerprint reader is
still required.