### PR TITLE
egistec: nile: New stock firmware now uses the Ganges HAL.

### DIFF
--- a/egistec/nile/EGISAPTrustlet.h
+++ b/egistec/nile/EGISAPTrustlet.h
@@ -298,6 +298,8 @@ class EGISAPTrustlet : public QSEETrustlet {
    public:
     EGISAPTrustlet();
 
+    bool MatchFirmware();
+
     int SendCommand(API &);
     int SendCommand(API &, Command);
     int SendCommand(Command);
@@ -307,6 +309,8 @@ class EGISAPTrustlet : public QSEETrustlet {
     int SendExtraCommand(ExtraCommand);
 
     // Helper calls:
+    size_t GetBlob(API &, ExtraCommand, void *, size_t);
+    size_t GetBlob(ExtraCommand, void *, size_t);
     uint64_t CallFor64BitResponse(API &, ExtraCommand);
     uint64_t CallFor64BitResponse(ExtraCommand);
 


### PR DESCRIPTION
Oh no! I screamed when seeing the FPC HAL fail on Discovery (Nile platform) just after flashing stock. This updates the firmware partition, and as it turns out they are now using the "new" Ganges HAL. :relieved: ... that saves time implementing yet another one.

> The TrustZone application that comes from the firmware partition is
> updated by (one of) the latest stock updates, switching it over to the
> same "new" API that's also in use by Ganges.
> Check for this by "reading" a random number. If the size field (which
> probably means something entirely different) is not set to the expected
> value of 8 bytes, this must be the other HAL.
> 
> Note: There are perhaps other ways to detect this, but this is the
> earliest error that is thrown, and seemingly the easiest and/or most
> harmless (ExtraCommands have 0xa in the first byte, whereas all Ganges
> trustlet_buffer_t calls start with 0xe0).

This could have been done with a lot less code (`GetRand64() == -1`), but I want to check for the size "mismatch" specifically.