### PR TITLE
Egistec: Nile: Fix missed comparison of different signs.

### DIFF
--- a/egistec/nile/EGISAPTrustlet.cpp
+++ b/egistec/nile/EGISAPTrustlet.cpp
@@ -151,7 +151,7 @@ size_t EGISAPTrustlet::GetBlob(EGISAPTrustlet::API &lockedBuffer, ExtraCommand c
         ALOGE("%s failed with %d", __func__, rc);
         return -1;
     }
-    if (extraOut.data_size > max_data) {
+    if ((size_t)extraOut.data_size > max_data) {
         ALOGW("%s returned more data than expected, %d > %zu", __func__, extraOut.data_size, max_data);
     }
 


### PR DESCRIPTION
Somehow the Android 10 compiler setup does not generate even a warning
for these, while it results in a hard error in other trees.

Yeah, I just overlooked this one while quickly hacking up a solution for broken Nile FPC.