### PR TITLE
ion_buffer: Implement with backwards-compatible libion.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -10,6 +10,7 @@ LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_SRC_FILES := \
     $(call all-subdir-cpp-files) \
     QSEEComFunc.c \
+    ion_buffer.c \
     common.c
 
 ifeq ($(filter-out loire tone,$(SOMC_PLATFORM)),)

--- a/Android.mk
+++ b/Android.mk
@@ -47,14 +47,15 @@ LOCAL_SRC_FILES -= BiometricsFingerprint.cpp
 endif
 
 LOCAL_SHARED_LIBRARIES := \
+    android.hardware.biometrics.fingerprint@2.1 \
     libcutils \
-    liblog \
+    libdl \
+    libhardware \
     libhidlbase \
     libhidltransport \
-    libhardware \
-    libutils \
-    libdl \
-    android.hardware.biometrics.fingerprint@2.1
+    libion \
+    liblog \
+    libutils
 
 LOCAL_CONLYFLAGS := -std=c99
 

--- a/IonBuffer.cpp
+++ b/IonBuffer.cpp
@@ -1,94 +1,20 @@
 #include "IonBuffer.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <linux/msm_ion.h>
-#include <string.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <unistd.h>
 #include <algorithm>
 
 #define LOG_TAG "FPC"
 #include <log/log.h>
 
-int IonBuffer::ion_dev_fd = -1;
-
-int IonBuffer::IonDev() {
-    if (ion_dev_fd >= 0)
-        return ion_dev_fd;
-
-    ion_dev_fd = open("/dev/ion", O_RDONLY);
-    LOG_ALWAYS_FATAL_IF(ion_dev_fd < 0, "Failed to open /dev/ion: %s", strerror(errno));
-
-    return ion_dev_fd;
-}
-
-IonBuffer::IonBuffer(size_t sz) : mRequestedSize(sz), mSize((sz + ION_ALIGN_MASK) & ~ION_ALIGN_MASK) {
-    int rc = 0;
-
-    int ion_fd = IonDev();
-
-    /* Allocate buffer */
-
-    struct ion_allocation_data ion_alloc_data = {
-        .len = mSize,
-        .align = ION_ALIGN,
-        .heap_id_mask = ION_HEAP(ION_QSECOM_HEAP_ID),
-    };
-
-    rc = ioctl(ion_fd, ION_IOC_ALLOC, &ion_alloc_data);
-    LOG_ALWAYS_FATAL_IF(rc, "Failed to allocate ION buffer");
-
-    mHandle = ion_alloc_data.handle;
-
-    /* Map buffer to fd */
-
-    struct ion_fd_data ifd_data = {
-        .handle = mHandle,
-    };
-
-    rc = ioctl(ion_fd, ION_IOC_MAP, &ifd_data);
-    LOG_ALWAYS_FATAL_IF(rc, "Failed to map ION buffer");
-
-    mFd = ifd_data.fd;
-
-    mMapped = (unsigned char *)mmap(NULL, mSize,
-                                    PROT_READ | PROT_WRITE,
-                                    MAP_SHARED, ifd_data.fd, 0);
-    LOG_ALWAYS_FATAL_IF(mMapped == MAP_FAILED, "Failed to mmap ION buffer");
+IonBuffer::IonBuffer(size_t sz) {
+    qcom_km_ion_memalloc(&ion_info, sz);
 }
 
 IonBuffer::~IonBuffer() {
-    int rc = 0;
-
-    if (mMapped) {
-        rc = munmap(mMapped, mSize);
-        LOG_ALWAYS_FATAL_IF(rc, "Failed to munmap ION buffer");
-        mMapped = nullptr;
-    }
-
-    if (mFd >= 0) {
-        rc = close(mFd);
-        LOG_ALWAYS_FATAL_IF(rc, "Failed to close ION buffer");
-        mFd = -1;
-    }
-
-    if (mHandle) {
-        struct ion_handle_data handle_data = {.handle = mHandle};
-        rc = ioctl(IonDev(), ION_IOC_FREE, &handle_data);
-        LOG_ALWAYS_FATAL_IF(rc, "Failed to free ION buffer");
-        mHandle = 0;
-    }
-
-    mSize = -1;
+    qcom_km_ion_dealloc(&ion_info);
 }
 
 IonBuffer::IonBuffer(IonBuffer &&other) {
-    std::swap(mSize, other.mSize);
-    std::swap(mFd, other.mFd);
-    std::swap(mHandle, other.mHandle);
-    std::swap(mMapped, other.mMapped);
+    std::swap(ion_info, other.ion_info);
 }
 
 IonBuffer &IonBuffer::operator=(IonBuffer &&other) {
@@ -97,21 +23,21 @@ IonBuffer &IonBuffer::operator=(IonBuffer &&other) {
 }
 
 size_t IonBuffer::size() const {
-    return mSize;
+    return ion_info.sbuf_len;
 }
 
 size_t IonBuffer::requestedSize() const {
-    return mRequestedSize;
+    return ion_info.req_len;
 }
 
 int IonBuffer::fd() const {
-    return mFd;
+    return ion_info.ifd_data_fd;
 }
 
 void *IonBuffer::operator()() {
-    return mMapped;
+    return ion_info.ion_sbuffer;
 }
 
 const void *IonBuffer::operator()() const {
-    return mMapped;
+    return ion_info.ion_sbuffer;
 }

--- a/IonBuffer.h
+++ b/IonBuffer.h
@@ -1,19 +1,9 @@
 #pragma once
-#include <stdint.h>
-// WARNING: Must include stdint before msm_ion, or it'll miss the size_t definition!
-#include <linux/msm_ion.h>
+
+#include "ion_buffer.h"
 
 class IonBuffer {
-    static constexpr size_t ION_ALIGN = 0x1000;
-    static constexpr size_t ION_ALIGN_MASK = ION_ALIGN - 1;
-
-    size_t mRequestedSize, mSize;
-    int mFd = -1;
-    ion_user_handle_t mHandle = 0;
-    void *mMapped = nullptr;
-
-    static int ion_dev_fd;
-    static int IonDev();
+    qcom_km_ion_info_t ion_info;
 
    public:
     IonBuffer(size_t);
@@ -30,6 +20,8 @@ class IonBuffer {
 
     void *operator()();
     const void *operator()() const;
+
+    static IonBuffer Wrap(int fd, ion_user_handle_t handle, void *buffer);
 };
 
 template <typename T>

--- a/QSEEComFunc.h
+++ b/QSEEComFunc.h
@@ -24,11 +24,10 @@
 #include <sys/mman.h>
 #include <fcntl.h> // open function
 #include <unistd.h> // close function
-#include <linux/msm_ion.h>
 #include "QSEEComAPI.h"
+#include "ion_buffer.h"
 
 // Forward declarations
-struct qcom_km_ion_info_t;
 struct qsee_handle_t;
 
 
@@ -47,8 +46,6 @@ typedef int (*set_bandwidth_def)(struct QSEECom_handle *handle, bool high);
 typedef int (*app_load_query_def)(struct QSEECom_handle *handle, char *app_name);
 
 // Utility functions
-typedef int32_t (*ion_free_def)(struct qcom_km_ion_info_t *handle);
-typedef int32_t (*ion_alloc_def)(struct qcom_km_ion_info_t *handle, uint32_t size);
 typedef int32_t (*load_trustlet_def)(struct qsee_handle_t* qsee_handle, struct QSEECom_handle **clnt_handle,const char *path, const char *fname, uint32_t sb_size);
 
 
@@ -72,14 +69,6 @@ typedef struct qsee_handle_t {
     ion_alloc_def ion_alloc;
     load_trustlet_def load_trustlet;
 } qsee_handle_t;
-
-struct qcom_km_ion_info_t {
-    int32_t ion_fd;
-    int32_t ifd_data_fd;
-    struct ion_handle_data ion_alloc_handle;
-    unsigned char * ion_sbuffer;
-    uint32_t sbuf_len;
-};
 
 int qsee_open_handle(struct qsee_handle_t **handle);
 int qsee_free_handle(struct qsee_handle_t** handle);

--- a/ion_buffer.c
+++ b/ion_buffer.c
@@ -1,0 +1,104 @@
+/**
+ *
+ *
+ */
+
+#include "ion_buffer.h"
+
+#define LOG_TAG "FPC"
+#include <log/log.h>
+
+#define ION_ALIGN 0x1000
+#define ION_ALIGN_MASK (ION_ALIGN - 1)
+
+__BEGIN_DECLS
+
+static int open_ion_device() {
+    int ion_dev_fd = open("/dev/ion", O_RDONLY);
+
+    LOG_ALWAYS_FATAL_IF(ion_dev_fd < 0, "Failed to open /dev/ion: %s", strerror(errno));
+
+    return ion_dev_fd;
+}
+
+int32_t qcom_km_ion_memalloc(struct qcom_km_ion_info_t *handle, size_t size) {
+    size_t aligned_size = (size + ION_ALIGN_MASK) & ~ION_ALIGN_MASK;
+    int rc = 0;
+
+    int ion_fd = open_ion_device();
+
+    /* Allocate buffer */
+
+    struct ion_allocation_data ion_alloc_data = {
+        .len = aligned_size,
+        .align = ION_ALIGN,
+        .heap_id_mask = ION_HEAP(ION_QSECOM_HEAP_ID),
+    };
+
+    rc = ioctl(ion_fd, ION_IOC_ALLOC, &ion_alloc_data);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to allocate ION buffer");
+
+    ion_user_handle_t user_handle = ion_alloc_data.handle;
+
+    /* Map buffer to fd */
+
+    struct ion_fd_data ifd_data = {
+        .handle = user_handle,
+    };
+
+    rc = ioctl(ion_fd, ION_IOC_MAP, &ifd_data);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to map ION buffer");
+
+    int data_fd = ifd_data.fd;
+
+    /* Map buffer to memory */
+
+    unsigned char *mapped = (unsigned char *)mmap(NULL, aligned_size,
+                                                  PROT_READ | PROT_WRITE,
+                                                  MAP_SHARED, ifd_data.fd, 0);
+    LOG_ALWAYS_FATAL_IF(mapped == MAP_FAILED, "Failed to mmap ION buffer");
+
+    *handle = (struct qcom_km_ion_info_t){
+        .ion_fd = ion_fd,
+        .ifd_data_fd = data_fd,
+        .handle = user_handle,
+        .ion_sbuffer = mapped,
+        .sbuf_len = aligned_size,
+        .req_len = size,
+    };
+
+    return 0;
+}
+
+int32_t qcom_km_ion_dealloc(struct qcom_km_ion_info_t *handle) {
+    int rc = 0;
+
+    if (handle->ion_sbuffer) {
+        rc = munmap(handle->ion_sbuffer, handle->sbuf_len);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to munmap ION buffer");
+        handle->ion_sbuffer = NULL;
+    }
+
+    if (handle->ifd_data_fd >= 0) {
+        rc = close(handle->ifd_data_fd);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to close ION buffer");
+        handle->ifd_data_fd = -1;
+    }
+
+    if (handle->handle) {
+        struct ion_handle_data handle_data = {.handle = handle->handle};
+        rc = ioctl(handle->ion_fd, ION_IOC_FREE, &handle_data);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to free ION buffer");
+        handle->handle = 0;
+    }
+
+    if (handle->ion_fd >= 0) {
+        rc = close(handle->ion_fd);
+        LOG_ALWAYS_FATAL_IF(rc, "Failed to close ION device");
+        handle->ion_fd = -1;
+    }
+
+    return rc;
+}
+
+__END_DECLS

--- a/ion_buffer.h
+++ b/ion_buffer.h
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <ion/ion.h>
 #include <string.h>
 #include <sys/cdefs.h>
 #include <sys/ioctl.h>
@@ -19,7 +20,6 @@ __BEGIN_DECLS
 struct qcom_km_ion_info_t {
     int ion_fd;
     int ifd_data_fd;
-    ion_user_handle_t handle;
     unsigned char *ion_sbuffer;
     uint32_t req_len, sbuf_len;
 };

--- a/ion_buffer.h
+++ b/ion_buffer.h
@@ -1,0 +1,35 @@
+
+#ifndef __ION_WRAPPER_H_
+#define __ION_WRAPPER_H_
+
+#include <stdint.h>
+// WARNING: Must include stdint before msm_ion, or it'll miss the size_t definition!
+#include <linux/msm_ion.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+__BEGIN_DECLS
+
+struct qcom_km_ion_info_t {
+    int ion_fd;
+    int ifd_data_fd;
+    ion_user_handle_t handle;
+    unsigned char *ion_sbuffer;
+    uint32_t req_len, sbuf_len;
+};
+
+typedef int32_t (*ion_free_def)(struct qcom_km_ion_info_t *handle);
+typedef int32_t (*ion_alloc_def)(struct qcom_km_ion_info_t *handle, size_t size);
+
+int32_t qcom_km_ion_memalloc(struct qcom_km_ion_info_t *handle, size_t size);
+int32_t qcom_km_ion_dealloc(struct qcom_km_ion_info_t *handle);
+
+__END_DECLS
+
+#endif


### PR DESCRIPTION
libion is a kernel-agnostic library that provides helpers for
allocation, deallocation, mapping and more. Instead of relying on kernel
headers to define TARGET_ION_ABI_VERSION, it checks the presence of a
new/legacy interface by testing the deprecated ION_IOC_FREE ioctl (the
only way to make a kernel-agnostic library is by checking at runtime).
Using this library is the way forward if we want to maintain an
implementation compatible with Linux 4.9, 4.14 and whatever the future
holds.

One of the major changes in the new API is the removal of the user
handle. Instead all buffers are referred by their fd. This provides
significant improvements to the API since an fd can be:
- used as handle;
- shared between processes;
- mmap()'ed;
- close()'d.
It greatly decreases the number of ioctls related to buffers (merely one
for allocation, and an unrelated one for heap queries) since the other
functionalities are either inferred or available through standard unix
calls.

Unfortunately ion_map() rejects any call on a non-legacy (4.12+) kernel,
instead of doing just the mmap. This is most likely because it passes
back _a separate fd_ acquired through ION_IOC_MAP which needs to be
closed separately (and does not exist in the non-legacy implementation).
Instead of adding a switch in the code that manages the extra fd on
legacy kernel builds, use ion_alloc_fd(). It "shares" the allocated user
handle on legacy kernels, giving a sharable fd that can also be mapped.
Curiously, it is possible to immediately close the ion user handle after
sharing, since that keeps the buffer open.
On non-legacy kernel implementations it simply calls the new allocation
ioctl, which returns a mappable fd immediately.

My only gripe with libion is that it calls its helper function ion_free
(which in turn uses ion_ioctl) to test for a legacy implementation. This
function logs a nasty, _useless_ error message:
E ion     : ioctl c0044901 failed with code -1: Invalid argument