### PR TITLE
yoshino: Disable fingerprint gestures.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,6 +21,7 @@ endif
 ifeq ($(filter-out yoshino,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
+LOCAL_CFLAGS += -DUSE_FPC_YOSHINO
 endif
 
 ifeq ($(filter-out nile,$(SOMC_PLATFORM)),)

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -473,7 +473,12 @@ err_t fpc_capture_image(fpc_imp_data_t *data)
 
 bool fpc_navi_supported(fpc_imp_data_t __unused *data)
 {
+#ifdef USE_FPC_YOSHINO
+    // The TZ-app crashes the entire phone with this feature.
+    return false;
+#else
     return true;
+#endif
 }
 
 err_t fpc_navi_enter(fpc_imp_data_t *data)


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/502

Yoshino devices crash after a minute with this feature enabled. There is
no way for us to debug or fix it, as it is most likely a TZ-app issue
which cannot be resolved. Disable the feature completely to prevent
calling any of these navigation functions giving the user an unusable
device.

@stefanhh0 If you or anyone wants this feature, I can transplant the Loire implementation to Yoshino. Perhaps there's a desync and this is the way to solve it. If this resolves the crashes, it most likely results in a phone that freezes the GPU while a finger is on the sensor :see_no_evil: 
Even if it does (and the feature is thus unusable), we at least know what the root cause is.