### PR TITLE
Yoshino build fix: Remove mDevice parameter

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -531,7 +531,7 @@ void BiometricsFingerprint::AuthenticateAsync() {
                 result = fpc_init(&mDevice->fpc, mWt.getEventFd());
                 LOG_ALWAYS_FATAL_IF(result < 0, "REINITIALIZE: Failed to init fpc: %d", result);
 #ifdef USE_FPC_YOSHINO
-                int grp_err = __setActiveGroup(mDevice, gid);
+                int grp_err = __setActiveGroup(gid);
                 if (grp_err)
                     ALOGE("%s : Cannot reinitialize database", __func__);
 #else


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/503

Following commit activates the build flag USE_FPC_YOSHINO and thus triggers
the build bug
yoshino: Disable fingerprint gestures.
commit 9cf2f139bf2b5febda523fe384ccd7a61970580b

The wrong function call was introduced with
BiometricsFingerprint: Simplify this/device passing once more.
commit 75d6aa806f1ebf33252a87f30060411c8a1360b1