### PR TITLE
BiometricsFingerprint: uinput: fall back to write on older kernels

### DIFF
--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -160,6 +160,7 @@ err_t send_buffer_command(fpc_data_t *ldata, uint32_t group_id, uint32_t cmd_id,
 
     if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
+        ldata->qsee_handle->ion_free(&ihandle);
         return -1;
     }
 
@@ -184,6 +185,7 @@ err_t send_command_result_buffer(fpc_data_t *ldata, uint32_t group_id, uint32_t 
 
     if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
+        ldata->qsee_handle->ion_free(&ihandle);
         return -1;
     }
     memcpy(buffer, &keydata_cmd->data[0], length);
@@ -207,6 +209,7 @@ err_t send_custom_cmd(fpc_data_t *ldata, void *buffer, uint32_t len)
 
     if(send_modified_command_to_tz(ldata, ihandle) < 0) {
         ALOGE("Error sending data to tz\n");
+        ldata->qsee_handle->ion_free(&ihandle);
         return -1;
     }
 

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -90,7 +90,7 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
     struct QSEECom_handle *handle = ldata->fpc_handle;
 
     fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) handle->ion_sbuffer;
-    void *rec_cmd = handle->ion_sbuffer + TZ_RESPONSE_OFFSET;
+    int32_t *rec_cmd = (int32_t*)(handle->ion_sbuffer + TZ_RESPONSE_OFFSET);
     struct QSEECom_ion_fd_info  ion_fd_info;
 
     memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));
@@ -98,7 +98,7 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
     ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
     ion_fd_info.data[0].cmd_buf_offset = 4;
 
-    *(uint32_t*)rec_cmd = 0;
+    *rec_cmd = 0;
     send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
     uint32_t length = (ihandle.sbuf_len + 4095) & (~4095);
     send_cmd->length = length;
@@ -109,7 +109,7 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
         ALOGE("Error sending modified command: %d\n", result);
         return -1;
     }
-    if((result = *(int32_t*)rec_cmd) != 0)
+    if((result = *rec_cmd) != 0)
     {
         ALOGE("Error in tz command (%d) : %s\n", result, fpc_error_str(result));
         return -2;

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -98,6 +98,7 @@ err_t send_modified_command_to_tz(fpc_data_t *ldata, struct qcom_km_ion_info_t i
     ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
     ion_fd_info.data[0].cmd_buf_offset = 4;
 
+    *(uint32_t*)rec_cmd = 0;
     send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
     uint32_t length = (ihandle.sbuf_len + 4095) & (~4095);
     send_cmd->length = length;


### PR DESCRIPTION
On sailfish XA2 we are currently on 4.4 kernel and this kernel
does not support UI_DEV_SETUP. We need to use the newer fingerprint
HAL since flashing Android 9 with Emma and then SailfishOS currently
breaks fingerprint on SailfishOS. Backporting the fixes for that would
also be an option but staying with upstream vendor-sony-oss-fingerprint
seems better.

So fallback to write if ioctl UI_DEV_SETUP fails in order to avoid
a crashing android.hardware.biometrics.fingerprint service.