### PR TITLE
nile: fpc: disable navi commands since they seem to be unsupported

### DIFF
--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -473,8 +473,9 @@ err_t fpc_capture_image(fpc_imp_data_t *data)
 
 bool fpc_navi_supported(fpc_imp_data_t __unused *data)
 {
-#ifdef USE_FPC_YOSHINO
-    // The TZ-app crashes the entire phone with this feature.
+#if defined(USE_FPC_YOSHINO) || defined(USE_FPC_NILE)
+    // On yoshino TZ-app crashes the entire phone with this feature.
+    // On nile this seems to be unsupported and results in FPC_ERROR_CONFIG
     return false;
 #else
     return true;


### PR DESCRIPTION
This is done by keeping track whether the navi commands fail initially
and if they do then don't try entering the navi state again.

Hopefully we don't need to merge this :).