### PR TITLE
[4/4] Support et6xx sensors on Kumano

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,14 @@ UseTab: Never
 PointerAlignment: Right
 NamespaceIndentation: None
 ColumnLimit: 0
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Relative includes first:
+  - Regex:           '^".*'
+    Priority:        1
+  # Other (local or global) includes:
+  - Regex:           '^<.*\.h>'
+    Priority:        2
+  # std includes last; prevent as much leaking as possible:
+  - Regex:           '^<.*'
+    Priority:        3

--- a/Android.mk
+++ b/Android.mk
@@ -40,6 +40,10 @@ ifeq ($(filter-out ganges,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += -DUSE_FPC_GANGES
 endif
 
+ifeq ($(filter-out kumano,$(SOMC_PLATFORM)),)
+LOCAL_CFLAGS += -DUSE_FPC_KUMANO
+endif
+
 ifneq ($(HAS_FPC),true)
 # This file heavily depends on fpc_ implementations from the
 # above fpc_imp_* files. There is no sensible default file

--- a/egistec/EgisFpDevice.cpp
+++ b/egistec/EgisFpDevice.cpp
@@ -1,9 +1,11 @@
 #include "EgisFpDevice.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
 #include <string.h>
 #include <unistd.h>
+
 #include <FormatException.hpp>
 
 namespace egistec {

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -1,4 +1,5 @@
 #include "BiometricsFingerprint.h"
+
 #include "FormatException.hpp"
 
 #define LOG_TAG "FPC ET"

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -33,6 +33,9 @@ BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : mDev(std::mov
     rc = mTrustlet.Calibrate();
     LOG_ALWAYS_FATAL_IF(rc, "Calibrate failed with rc = %d", rc);
 
+    mHwId = mTrustlet.GetHwId();
+    ALOGI("HWID: %x", mHwId);
+
     mWt.Start();
 }
 

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -4,7 +4,7 @@
 #define LOG_TAG "FPC ET"
 #include <log/log.h>
 
-namespace egistec::ganges {
+namespace egistec::current {
 
 using namespace ::SynchronizedWorker;
 
@@ -748,4 +748,4 @@ void BiometricsFingerprint::NotifyRemove(uint32_t fid, uint32_t remaining) {
             remaining);
 }
 
-}  // namespace egistec::ganges
+}  // namespace egistec::current

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -443,9 +443,17 @@ void BiometricsFingerprint::AuthenticateAsync() {
 }
 
 void BiometricsFingerprint::IdleAsync() {
-    DeviceEnableGuard<EgisFpDevice> guard{mDev};
     int rc = 0;
     int which;
+
+    if (mHwId >= 0x600) {
+        // 6xx does not support gestures.
+        rc = mTrustlet.SetWorkMode(WorkMode::Sleep);
+        LOG_ALWAYS_FATAL_IF(rc, "SetWorkMode(WorkMode::Sleep) failed with rc=%d", rc);
+        return WorkHandler::IdleAsync();
+    }
+
+    DeviceEnableGuard<EgisFpDevice> guard{mDev};
 
     rc = mTrustlet.SetWorkMode(WorkMode::NavigationDetect);
     LOG_ALWAYS_FATAL_IF(rc, "SetWorkMode(WorkMode::NavigationDetect) failed with rc=%d", rc);

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -393,6 +393,12 @@ void BiometricsFingerprint::AuthenticateAsync() {
                 }
                 break;
         }
+
+        if (rc == 99) {
+            ALOGW("Resetting device...");
+            rc = mDev.Reset();
+            ALOGE_IF(rc, "%s: Failed to reset device, rc = %d", __func__, rc);
+        }
     }
 
     mTrustlet.SetSpiState(0);
@@ -674,6 +680,12 @@ void BiometricsFingerprint::EnrollAsync() {
                         timeout = true;
                 }
                 break;
+        }
+
+        if (rc == 99) {
+            ALOGW("Resetting device...");
+            rc = mDev.Reset();
+            ALOGE_IF(rc, "%s: Failed to reset device, rc = %d", __func__, rc);
         }
     }
 

--- a/egistec/current/BiometricsFingerprint.h
+++ b/egistec/current/BiometricsFingerprint.h
@@ -14,7 +14,7 @@
 #include "QSEEKeymasterTrustlet.h"
 #include "UInput.h"
 
-namespace egistec::ganges {
+namespace egistec::current {
 
 using ::android::sp;
 using ::android::hardware::hidl_array;
@@ -75,4 +75,4 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public ::Synchroni
     void NotifyRemove(uint32_t fid, uint32_t remaining);
 };
 
-}  // namespace egistec::ganges
+}  // namespace egistec::current

--- a/egistec/current/BiometricsFingerprint.h
+++ b/egistec/current/BiometricsFingerprint.h
@@ -4,15 +4,16 @@
 
 #pragma once
 
-#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
-
-#include <EventMultiplexer.h>
-#include <SynchronizedWorkerThread.h>
-#include <egistec/EgisFpDevice.h>
-#include <array>
 #include "EGISAPTrustlet.h"
 #include "QSEEKeymasterTrustlet.h"
 #include "UInput.h"
+
+#include <EventMultiplexer.h>
+#include <SynchronizedWorkerThread.h>
+#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
+#include <egistec/EgisFpDevice.h>
+
+#include <array>
 
 namespace egistec::current {
 

--- a/egistec/current/BiometricsFingerprint.h
+++ b/egistec/current/BiometricsFingerprint.h
@@ -54,6 +54,7 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public ::Synchroni
     std::mutex mClientCallbackMutex;
     UInput uinput;
     uint32_t mGid = -1;
+    uint32_t mHwId;
     ::SynchronizedWorker::Thread mWt;
     EventMultiplexer mMux;
 

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -6,7 +6,7 @@
 // #define LOG_NDEBUG 0
 #include <log/log.h>
 
-namespace egistec::ganges {
+namespace egistec::current {
 
 void log_hex(const char *data, int length) {
     if (length <= 0 || data == NULL)
@@ -437,4 +437,4 @@ int EGISAPTrustlet::UpdateTemplate(bool &updated) {
     return 0;
 }
 
-}  // namespace egistec::ganges
+}  // namespace egistec::current

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -1,6 +1,8 @@
 #include "EGISAPTrustlet.h"
-#include <string.h>
+
 #include "FormatException.hpp"
+
+#include <string.h>
 
 #define LOG_TAG "FPC ET"
 // #define LOG_NDEBUG 0

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -230,6 +230,13 @@ int EGISAPTrustlet::UninitializeSensor() {
     return SendCommand(CommandId::UninitializeSensor);
 }
 
+uint32_t EGISAPTrustlet::GetHwId() {
+    TypedIonBuffer<uint32_t> id;
+    int rc = SendModifiedCommand(id, CommandId::GetHwId);
+    LOG_ALWAYS_FATAL_IF(rc, "Failed to get hardware ID!");
+    return *id;
+}
+
 uint64_t EGISAPTrustlet::GetAuthenticatorId() {
     TypedIonBuffer<uint64_t> id;
     auto api = GetLockedAPI();

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -193,37 +193,6 @@ int EGISAPTrustlet::GetNavEvent(int &which) {
     return 0;
 }
 
-int EGISAPTrustlet::GetPrintIds(uint32_t gid, std::vector<uint32_t> &list) {
-    struct print_ids_t {
-        uint32_t ids[5];
-        uint32_t num_prints;
-    };
-
-    TypedIonBuffer<print_ids_t> prints;
-    auto api = GetLockedAPI();
-
-    int rc = SendModifiedCommand(api, prints, CommandId::GetPrintIds, gid);
-    if (rc)
-        return rc;
-
-    LOG_ALWAYS_FATAL_IF(api.Base().extra_buffer_size != sizeof(print_ids_t),
-                        "%s: did not return exactly sizeof(print_ids_t) bytes!",
-                        __func__);
-
-    ALOGD("GetFingerList reported %d fingers", prints->num_prints);
-
-    list.clear();
-    list.reserve(prints->num_prints);
-    std::copy(prints->ids,
-              prints->ids + prints->num_prints,
-              std::back_inserter(list));
-
-    for (auto p : list)
-        ALOGD("Print: %u", p);
-
-    return 0;
-}
-
 int EGISAPTrustlet::InitializeAlgo() {
     return SendCommand(CommandId::InitializeAlgo);
 }
@@ -376,6 +345,37 @@ int EGISAPTrustlet::SaveEnrolledPrint(uint32_t gid, uint64_t fid) {
 
 int EGISAPTrustlet::FinalizeEnroll() {
     return SendCommand(CommandId::FinalizeEnroll);
+}
+
+int EGISAPTrustlet::GetPrintIds(uint32_t gid, std::vector<uint32_t> &list) {
+    struct print_ids_t {
+        uint32_t ids[5];
+        uint32_t num_prints;
+    };
+
+    TypedIonBuffer<print_ids_t> prints;
+    auto api = GetLockedAPI();
+
+    int rc = SendModifiedCommand(api, prints, CommandId::GetPrintIds, gid);
+    if (rc)
+        return rc;
+
+    LOG_ALWAYS_FATAL_IF(api.Base().extra_buffer_size != sizeof(print_ids_t),
+                        "%s: did not return exactly sizeof(print_ids_t) bytes!",
+                        __func__);
+
+    ALOGD("GetFingerList reported %d fingers", prints->num_prints);
+
+    list.clear();
+    list.reserve(prints->num_prints);
+    std::copy(prints->ids,
+              prints->ids + prints->num_prints,
+              std::back_inserter(list));
+
+    for (auto p : list)
+        ALOGD("Print: %u", p);
+
+    return 0;
 }
 
 int EGISAPTrustlet::RemovePrint(uint32_t gid, uint32_t fid) {

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -49,7 +49,11 @@ void log_hex(const char *data, int length) {
     free(base);
 }
 
+#ifdef USE_FPC_KUMANO
+EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet("egista", 0x2400, /* path: */ "/odm/firmware") {
+#else
 EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet("egisap32", 0x2400) {
+#endif
 }
 
 int EGISAPTrustlet::SendCommand(EGISAPTrustlet::API &api) {

--- a/egistec/current/EGISAPTrustlet.h
+++ b/egistec/current/EGISAPTrustlet.h
@@ -1,13 +1,15 @@
 #pragma once
 
+#include "QSEEKeymasterTrustlet.h"
+#include "QSEETrustlet.h"
+
 #include <IonBuffer.h>
 #include <arpa/inet.h>
 #include <hardware/hw_auth_token.h>
 #include <string.h>
+
 #include <algorithm>
 #include <vector>
-#include "QSEEKeymasterTrustlet.h"
-#include "QSEETrustlet.h"
 
 namespace egistec::current {
 

--- a/egistec/current/EGISAPTrustlet.h
+++ b/egistec/current/EGISAPTrustlet.h
@@ -9,7 +9,7 @@
 #include "QSEEKeymasterTrustlet.h"
 #include "QSEETrustlet.h"
 
-namespace egistec::ganges {
+namespace egistec::current {
 
 enum class CommandId : uint32_t {
     SetMasterKey = 0,
@@ -233,4 +233,4 @@ class EGISAPTrustlet : public QSEETrustlet {
     int UpdateTemplate(bool &updated);
 };
 
-}  // namespace egistec::ganges
+}  // namespace egistec::current

--- a/egistec/current/EGISAPTrustlet.h
+++ b/egistec/current/EGISAPTrustlet.h
@@ -199,7 +199,6 @@ class EGISAPTrustlet : public QSEETrustlet {
 
     int Calibrate();
     int GetNavEvent(int &which);
-    int GetPrintIds(uint32_t gid, std::vector<uint32_t> &);
     int InitializeAlgo();
     int InitializeSensor();
     int SetDataPath(const char *);
@@ -225,8 +224,11 @@ class EGISAPTrustlet : public QSEETrustlet {
     int SaveEnrolledPrint(uint32_t gid, uint64_t fid);
     int FinalizeEnroll();
 
+    // Print management
+    int GetPrintIds(uint32_t gid, std::vector<uint32_t> &);
     int RemovePrint(uint32_t gid, uint32_t fid);
 
+    // Identification
     int FinalizeIdentify();
     int GetEnrolledCount(uint32_t &);
     int Identify(uint32_t gid, uint64_t opid, identify_result_t &);

--- a/egistec/current/EGISAPTrustlet.h
+++ b/egistec/current/EGISAPTrustlet.h
@@ -51,6 +51,8 @@ enum class CommandId : uint32_t {
 
     OpenSpi = 0x29,
     CloseSpi = 0x2a,
+
+    GetHwId = 0x64,
 };
 
 enum class ImageResult : uint32_t {
@@ -209,6 +211,7 @@ class EGISAPTrustlet : public QSEETrustlet {
     int UninitializeSdk();
     int UninitializeSensor();
 
+    uint32_t GetHwId();
     uint64_t GetAuthenticatorId();
 
     int GetImage(ImageResult &quality);

--- a/egistec/legacy/BiometricsFingerprint.cpp
+++ b/egistec/legacy/BiometricsFingerprint.cpp
@@ -1,5 +1,6 @@
-#include <FormatException.hpp>
 #include "BiometricsFingerprint.h"
+
+#include <FormatException.hpp>
 
 #define LOG_TAG "FPC ET"
 #include <log/log.h>

--- a/egistec/legacy/BiometricsFingerprint.cpp
+++ b/egistec/legacy/BiometricsFingerprint.cpp
@@ -4,7 +4,7 @@
 #define LOG_TAG "FPC ET"
 #include <log/log.h>
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 BiometricsFingerprint::BiometricsFingerprint(EgisFpDevice &&dev) : loops(reinterpret_cast<uint64_t>(this), std::move(dev)) {
     QSEEKeymasterTrustlet keymaster;
@@ -99,4 +99,4 @@ Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operationId, 
     return loops.Authenticate(operationId) ? RequestStatus::SYS_EINVAL : RequestStatus::SYS_OK;
 }
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/egistec/legacy/BiometricsFingerprint.h
+++ b/egistec/legacy/BiometricsFingerprint.h
@@ -4,11 +4,12 @@
 
 #pragma once
 
-#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
+#include "EgisOperationLoops.h"
 
 #include <QSEEKeymasterTrustlet.h>
+#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
+
 #include <array>
-#include "EgisOperationLoops.h"
 
 namespace egistec::legacy {
 

--- a/egistec/legacy/BiometricsFingerprint.h
+++ b/egistec/legacy/BiometricsFingerprint.h
@@ -10,7 +10,7 @@
 #include <array>
 #include "EgisOperationLoops.h"
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 using ::android::sp;
 using ::android::hardware::hidl_array;
@@ -44,4 +44,4 @@ struct BiometricsFingerprint : public IBiometricsFingerprint {
     EgisOperationLoops loops;
 };
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/egistec/legacy/EGISAPTrustlet.cpp
+++ b/egistec/legacy/EGISAPTrustlet.cpp
@@ -6,7 +6,7 @@
 // #define LOG_NDEBUG 0
 #include <log/log.h>
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 void log_hex(const char *data, int length) {
     if (length <= 0 || data == NULL)
@@ -337,4 +337,4 @@ int EGISAPTrustlet::SetMasterKey(const MasterKey &key) {
     return SendExtraCommand(lockedBuffer, ExtraCommand::SetMasterKey);
 }
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/egistec/legacy/EGISAPTrustlet.cpp
+++ b/egistec/legacy/EGISAPTrustlet.cpp
@@ -1,6 +1,8 @@
 #include "EGISAPTrustlet.h"
-#include <string.h>
+
 #include "FormatException.hpp"
+
+#include <string.h>
 
 #define LOG_TAG "FPC ET"
 // #define LOG_NDEBUG 0

--- a/egistec/legacy/EGISAPTrustlet.h
+++ b/egistec/legacy/EGISAPTrustlet.h
@@ -8,7 +8,7 @@
 #include "QSEEKeymasterTrustlet.h"
 #include "QSEETrustlet.h"
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 typedef struct {
     int qty;
@@ -350,4 +350,4 @@ class EGISAPTrustlet : public QSEETrustlet {
     int SetMasterKey(const MasterKey &);
 };
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/egistec/legacy/EGISAPTrustlet.h
+++ b/egistec/legacy/EGISAPTrustlet.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "QSEEKeymasterTrustlet.h"
+#include "QSEETrustlet.h"
+
 #include <arpa/inet.h>
 #include <hardware/hw_auth_token.h>
 #include <string.h>
+
 #include <algorithm>
 #include <vector>
-#include "QSEEKeymasterTrustlet.h"
-#include "QSEETrustlet.h"
 
 namespace egistec::legacy {
 

--- a/egistec/legacy/EgisOperationLoops.cpp
+++ b/egistec/legacy/EgisOperationLoops.cpp
@@ -3,15 +3,17 @@
 #if PLATFORM_SDK_VERSION >= 28
 #include <bits/epoll_event.h>
 #endif
+#include "EgisOperationLoops.h"
+#include "FormatException.hpp"
+
 #include <arpa/inet.h>
 #include <hardware/hw_auth_token.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/poll.h>
 #include <unistd.h>
+
 #include <algorithm>
-#include "EgisOperationLoops.h"
-#include "FormatException.hpp"
 
 #define LOG_TAG "FPC ET"
 #define LOG_NDEBUG 0

--- a/egistec/legacy/EgisOperationLoops.cpp
+++ b/egistec/legacy/EgisOperationLoops.cpp
@@ -17,7 +17,7 @@
 #define LOG_NDEBUG 0
 #include <log/log.h>
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 using ::android::hardware::hidl_vec;
 using namespace ::SynchronizedWorker;
@@ -627,4 +627,4 @@ error:
     return rc;
 }
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/egistec/legacy/EgisOperationLoops.h
+++ b/egistec/legacy/EgisOperationLoops.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "EGISAPTrustlet.h"
+
 #include <EventMultiplexer.h>
 #include <SynchronizedWorkerThread.h>
 #include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprintClientCallback.h>
 #include <egistec/EgisFpDevice.h>
 #include <sys/eventfd.h>
+
 #include <mutex>
-#include "EGISAPTrustlet.h"
 
 namespace egistec::legacy {
 

--- a/egistec/legacy/EgisOperationLoops.h
+++ b/egistec/legacy/EgisOperationLoops.h
@@ -8,7 +8,7 @@
 #include <mutex>
 #include "EGISAPTrustlet.h"
 
-namespace egistec::nile {
+namespace egistec::legacy {
 
 using ::android::sp;
 using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintAcquiredInfo;
@@ -92,4 +92,4 @@ class EgisOperationLoops : public EGISAPTrustlet, public ::SynchronizedWorker::W
     int Authenticate(uint64_t challenge);
 };
 
-}  // namespace egistec::nile
+}  // namespace egistec::legacy

--- a/service.cpp
+++ b/service.cpp
@@ -37,7 +37,7 @@ using CurrentEgistecHAL = ::egistec::current::BiometricsFingerprint;
 int main() {
     android::sp<IBiometricsFingerprint> bio;
 
-#if defined(USE_FPC_NILE) || defined(USE_FPC_GANGES)
+#if defined(USE_FPC_NILE) || defined(USE_FPC_GANGES) || defined(USE_FPC_KUMANO)
     ::egistec::EgisFpDevice dev;
 #endif
 
@@ -72,7 +72,7 @@ int main() {
             ALOGE("No HAL instance defined for hardware type %d", type);
             return 1;
     }
-#elif defined(USE_FPC_GANGES)
+#elif defined(USE_FPC_GANGES) || defined(USE_FPC_KUMANO)
     bio = new CurrentEgistecHAL(std::move(dev));
 #else
     bio = new FPCHAL();

--- a/service.cpp
+++ b/service.cpp
@@ -19,9 +19,9 @@
 #include <hidl/HidlSupport.h>
 #include <hidl/HidlTransportSupport.h>
 #include "BiometricsFingerprint.h"
-#include "egistec/ganges/BiometricsFingerprint.h"
-#include "egistec/nile/BiometricsFingerprint.h"
-#include "egistec/nile/EGISAPTrustlet.h"
+#include "egistec/current/BiometricsFingerprint.h"
+#include "egistec/legacy/BiometricsFingerprint.h"
+#include "egistec/legacy/EGISAPTrustlet.h"
 
 using android::NO_ERROR;
 using android::sp;
@@ -31,8 +31,8 @@ using android::hardware::joinRpcThreadpool;
 using android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
 
 using FPCHAL = ::fpc::BiometricsFingerprint;
-using NileHAL = ::egistec::nile::BiometricsFingerprint;
-using GangesHAL = ::egistec::ganges::BiometricsFingerprint;
+using LegacyEgistecHAL = ::egistec::legacy::BiometricsFingerprint;
+using CurrentEgistecHAL = ::egistec::current::BiometricsFingerprint;
 
 int main() {
     android::sp<IBiometricsFingerprint> bio;
@@ -50,18 +50,18 @@ int main() {
             ALOGI("Egistec sensor installed");
 
             {
-                ::egistec::nile::EGISAPTrustlet trustlet;
+                ::egistec::legacy::EGISAPTrustlet trustlet;
                 is_old_hal = trustlet.MatchFirmware();
                 // Scope closes trustlet. While this could be reused,
                 // opt for starting fresh in case the command introduces
                 // unexpected state changes.
             }
             if (is_old_hal) {
-                ALOGI("Using (old) Nile HAL");
-                bio = new NileHAL(std::move(dev));
+                ALOGI("Using legacy Egistec (Nile) HAL");
+                bio = new LegacyEgistecHAL(std::move(dev));
             } else {
-                ALOGI("Using (new) Ganges HAL on Nile");
-                bio = new GangesHAL(std::move(dev));
+                ALOGI("Using new Egistec (Ganges+) HAL on Nile");
+                bio = new CurrentEgistecHAL(std::move(dev));
             }
             break;
         case egistec::FpHwId::Fpc:
@@ -73,7 +73,7 @@ int main() {
             return 1;
     }
 #elif defined(USE_FPC_GANGES)
-    bio = new GangesHAL(std::move(dev));
+    bio = new CurrentEgistecHAL(std::move(dev));
 #else
     bio = new FPCHAL();
 #endif


### PR DESCRIPTION
Depends on: https://github.com/sonyxperiadev/kernel-defconfig/pull/71, https://github.com/sonyxperiadev/kernel/pull/2185, https://github.com/sonyxperiadev/device-sony-kumano/pull/19.

This patchset adds support for the ET603 sensor found in Kumano. Required hanges are minor, limited to disabling gestures and handling HW-reset requests (error `99`).
The rest is cleanup: Most notably namespacing of various components which have been renamed from nile/ganges to legacy/current, respectively.

### deficiencies
- This is the first driver+HAL combination to support "dynamic" power management (which we have found to work on any other sensor too), but it is only limited to powering the sensor up on HAL start and down on HAL shutdown.
  - Our power management works fine on other devices (nile/Ganges) without official support/implementation for powering down when not in use. Kumano however consistently returns an error 99 to reset the device, after it has been powered off.
  - Stock starts an authentication session with WaitFingerLost instead of WaitFingerDown. This results in an infinite error-99 loop on SPI enablement.
  - The solution seems to leave the FPC hardware powered at all times. Which anyway happens due to gestures running whenever no auth/enroll session is ongoing.
- Gestures will not work. The TZapp lacks the necessary functionality to support this feature.

### Test subjects
All prints deleted and rebooted to get a clean session. Registration of multiple prints, authentication and gestures (where supported) all function as expected:
- Discovery RoW (Egistec sensor, new TZapp)
- Mermaid DSDS
- Bahamut DSDS
- Griffin DSDS
- The race-condition in `SynchronizedWorkerThread` has been tested extensively on Akatsuki DSDS