### PR TITLE
[FINGERPRINT] Increase reliability of egistec sensor (current)

### DIFF
--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -587,6 +587,10 @@ void BiometricsFingerprint::EnrollAsync() {
                     case ImageResult::Partial:
                         NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_PARTIAL);
                         break;
+                    case ImageResult::ImagerDirty:
+                    case ImageResult::ImagerDirty9:
+                        NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_IMAGER_DIRTY);
+                        break;
                     default:
                         state = WaitFingerDown;
                         break;
@@ -634,6 +638,7 @@ void BiometricsFingerprint::EnrollAsync() {
                         // Sends ACQUIRED_VENDOR, or FINGERPRINT_ACQUIRED_DETECTED in old-skool libhardware
                         break;
                     case ImageResult::ImagerDirty:
+                    case ImageResult::ImagerDirty9:
                         NotifyAcquired(FingerprintAcquiredInfo::ACQUIRED_IMAGER_DIRTY);
                         break;
                     case ImageResult::Partial:

--- a/egistec/current/BiometricsFingerprint.h
+++ b/egistec/current/BiometricsFingerprint.h
@@ -70,6 +70,7 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public ::Synchroni
     void EnrollAsync() override;
     void IdleAsync() override;
 
+    int  ResetSensor();
     void NotifyAcquired(FingerprintAcquiredInfo);
     void NotifyAuthenticated(uint32_t fid, const hw_auth_token_t &hat);
     void NotifyEnrollResult(uint32_t fid, uint32_t remaining);


### PR DESCRIPTION
This patchset increases reliability of the egistec sensor, targeting SoMC Kumano platform.

A variant of this patch has been tested on SoMC Kumano Griffin DSDS by both me and @paulbouchara and has shown a LARGE reliability increase.

For me, before:
30 events -- 3 ACQUIRE OK - 3 ACQUIRE PARTIAL - 24 IMAGER DIRTY

After:
30 events -- 24 ACQUIRE OK - 6 IMAGER DIRTY

Please test this variant before merging.