### PR TITLE
egistec: current: Disable power control on Kumano

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,28 +16,37 @@ LOCAL_SRC_FILES := \
 ifeq ($(filter-out loire tone,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_loire_tone.c
 HAS_FPC := true
+LOCAL_CFLAGS += -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out yoshino,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
-LOCAL_CFLAGS += -DUSE_FPC_YOSHINO
+LOCAL_CFLAGS += \
+    -DUSE_FPC_YOSHINO \
+    -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out nile,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
-LOCAL_CFLAGS += -DUSE_FPC_NILE
+LOCAL_CFLAGS += \
+    -DUSE_FPC_NILE \
+    -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out tama,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
-LOCAL_CFLAGS += -DUSE_FPC_TAMA
+LOCAL_CFLAGS += \
+    -DUSE_FPC_TAMA \
+    -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out ganges,$(SOMC_PLATFORM)),)
-LOCAL_CFLAGS += -DUSE_FPC_GANGES
+LOCAL_CFLAGS += \
+    -DUSE_FPC_GANGES \
+    -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out kumano,$(SOMC_PLATFORM)),)


### PR DESCRIPTION
Kumano devices are the first with in-kernel (copyleft) power management
support. Unfortuately this only streches to HAL starts, the device is
left on after that indefinitely. Toggling power to save some microAmps
while running - which works on all platforms till now - make the sensor
on this device completely unresponsive, request HW resets and the like.
This is an unworkable solution that has to be disabled.
The preprocessor flag is spread to all platforms including non-egistec
ones in case we want to reuse it in the future for FPC.

Aside from that Kumano is the first platform where power management
remotely makes any sort of sense since there is no gesture support and
the sensor could realistically be off when the device is in use.

Some autoformats slipped in, too.

---

Tested on Bahamut DSDS.

@kholk this one is for you :wink: 