### PR TITLE
[FINGERPRINT] Stop using legacy /firmware folder

### DIFF
--- a/QSEETrustlet.h
+++ b/QSEETrustlet.h
@@ -6,7 +6,7 @@
 
 class QSEETrustlet {
    public:
-    QSEETrustlet(const char *app_name, uint32_t shared_buffer_size, const char *path = "/firmware/image");
+    QSEETrustlet(const char *app_name, uint32_t shared_buffer_size, const char *path = "/vendor/firmware_mnt/image");
     ~QSEETrustlet();
 
     // QSEETrustlet(const QSEETrustlet &) = delete;

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -892,12 +892,10 @@ err_t fpc_init(fpc_imp_data_t **data, int event_fd)
     }
 
     ALOGI("Starting app %s\n", KM_TZAPP_NAME);
-    if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_ALT_PATH, KM_TZAPP_NAME, 1024) < 0) {
-        if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_NAME, 1024) < 0) {
-            if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_ALT_NAME, 1024) < 0) {
-                 ALOGE("Could not load app %s or %s\n", KM_TZAPP_NAME, KM_TZAPP_ALT_NAME);
-                goto err_alloc;
-            }
+    if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_NAME, 1024) < 0) {
+        if (qsee_handle->load_trustlet(qsee_handle, &mKeymasterHandle, KM_TZAPP_PATH, KM_TZAPP_ALT_NAME, 1024) < 0) {
+            ALOGE("Could not load app " KM_TZAPP_NAME " or " KM_TZAPP_ALT_NAME " from " KM_TZAPP_PATH "\n");
+            goto err_alloc;
         }
     }
     fpc_data->qsee_handle = qsee_handle;

--- a/tz_api_loire_tone.h
+++ b/tz_api_loire_tone.h
@@ -26,7 +26,7 @@ extern "C" {
 #define FP_TZAPP_PATH "/odm/firmware/"
 #define FP_TZAPP_NAME "tzfingerprint"
 
-#define KM_TZAPP_PATH "/firmware/image/"
+#define KM_TZAPP_PATH "/vendor/firmware_mnt/image/"
 #define KM_TZAPP_NAME "keymaste"
 #define KM_TZAPP_ALT_NAME "keymaster"
 

--- a/tz_api_nile.h
+++ b/tz_api_nile.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#define FP_TZAPP_PATH "/firmware/image/"
+#define FP_TZAPP_PATH "/vendor/firmware_mnt/image/"
 #define FP_TZAPP_NAME "fpctzapp"
 
 #define KM_TZAPP_PATH "/system/etc/firmware"

--- a/tz_api_nile.h
+++ b/tz_api_nile.h
@@ -26,8 +26,7 @@ extern "C" {
 #define FP_TZAPP_PATH "/vendor/firmware_mnt/image/"
 #define FP_TZAPP_NAME "fpctzapp"
 
-#define KM_TZAPP_PATH "/system/etc/firmware"
-#define KM_TZAPP_ALT_PATH ""
+#define KM_TZAPP_PATH ""
 #define KM_TZAPP_NAME "keymaster64"
 #define KM_TZAPP_ALT_NAME ""
 

--- a/tz_api_tama.h
+++ b/tz_api_tama.h
@@ -26,8 +26,7 @@ extern "C" {
 #define FP_TZAPP_PATH "/odm/firmware/"
 #define FP_TZAPP_NAME "fpctzfingerprint"
 
-#define KM_TZAPP_PATH "/system/etc/firmware"
-#define KM_TZAPP_ALT_PATH ""
+#define KM_TZAPP_PATH ""
 #define KM_TZAPP_NAME "keymaster64"
 #define KM_TZAPP_ALT_NAME "keymaster"
 

--- a/tz_api_yoshino.h
+++ b/tz_api_yoshino.h
@@ -26,8 +26,7 @@ extern "C" {
 #define FP_TZAPP_PATH "/odm/firmware/"
 #define FP_TZAPP_NAME "tzfingerprint"
 
-#define KM_TZAPP_PATH "/system/etc/firmware"
-#define KM_TZAPP_ALT_PATH ""
+#define KM_TZAPP_PATH ""
 #define KM_TZAPP_NAME "keymaster64"
 #define KM_TZAPP_ALT_NAME "keymaster"
 


### PR DESCRIPTION
For https://github.com/sonyxperiadev/device-sony-sepolicy/pull/534

As it turns out we're using an unstable folder that may or may not be available at all, depending on the (SAR) GSI used. Point it to our own - known stable - `/vendor/firmware_mnt` instead.

Tested on Mermaid DSDS and Akatsuki DSDS.