### PR TITLE
[FPC] Delete all prints if fid=0; cleanups and reformats

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 BasedOnStyle: Google
 IndentWidth: 4
 UseTab: Never
+DerivePointerAlignment: false
 PointerAlignment: Right
 NamespaceIndentation: None
 ColumnLimit: 0

--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -30,8 +30,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <chrono>
-
 namespace fpc {
 
 using ::android::hardware::biometrics::fingerprint::V2_1::FingerprintAcquiredInfo;

--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -21,15 +21,16 @@
 
 #include "BiometricsFingerprint.h"
 
+#include "android-base/macros.h"
+
 #include <byteswap.h>
-#include <chrono>
 #include <inttypes.h>
 #include <stdio.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "android-base/macros.h"
+#include <chrono>
 
 namespace fpc {
 
@@ -41,7 +42,7 @@ using namespace ::SynchronizedWorker;
 BiometricsFingerprint::BiometricsFingerprint() : mWt(this), mClientCallback(nullptr), mDevice(nullptr) {
     fpc_imp_data_t *fpc_data = NULL;
 
-    mDevice = (sony_fingerprint_device_t*) malloc(sizeof(sony_fingerprint_device_t));
+    mDevice = (sony_fingerprint_device_t *)malloc(sizeof(sony_fingerprint_device_t));
     LOG_ALWAYS_FATAL_IF(!mDevice, "Failed to allocate sony_fingerprint_device_t");
     memset(mDevice, 0, sizeof(sony_fingerprint_device_t));
 
@@ -62,19 +63,31 @@ BiometricsFingerprint::~BiometricsFingerprint() {
 }
 
 Return<RequestStatus> BiometricsFingerprint::ErrorFilter(int32_t error) {
-    switch(error) {
-        case 0: return RequestStatus::SYS_OK;
-        case -2: return RequestStatus::SYS_ENOENT;
-        case -4: return RequestStatus::SYS_EINTR;
-        case -5: return RequestStatus::SYS_EIO;
-        case -11: return RequestStatus::SYS_EAGAIN;
-        case -12: return RequestStatus::SYS_ENOMEM;
-        case -13: return RequestStatus::SYS_EACCES;
-        case -14: return RequestStatus::SYS_EFAULT;
-        case -16: return RequestStatus::SYS_EBUSY;
-        case -22: return RequestStatus::SYS_EINVAL;
-        case -28: return RequestStatus::SYS_ENOSPC;
-        case -110: return RequestStatus::SYS_ETIMEDOUT;
+    switch (error) {
+        case 0:
+            return RequestStatus::SYS_OK;
+        case -2:
+            return RequestStatus::SYS_ENOENT;
+        case -4:
+            return RequestStatus::SYS_EINTR;
+        case -5:
+            return RequestStatus::SYS_EIO;
+        case -11:
+            return RequestStatus::SYS_EAGAIN;
+        case -12:
+            return RequestStatus::SYS_ENOMEM;
+        case -13:
+            return RequestStatus::SYS_EACCES;
+        case -14:
+            return RequestStatus::SYS_EFAULT;
+        case -16:
+            return RequestStatus::SYS_EBUSY;
+        case -22:
+            return RequestStatus::SYS_EINVAL;
+        case -28:
+            return RequestStatus::SYS_ENOSPC;
+        case -110:
+            return RequestStatus::SYS_ETIMEDOUT;
         default:
             ALOGE("An unknown error returned from fingerprint vendor library: %d", error);
             return RequestStatus::SYS_UNKNOWN;
@@ -82,7 +95,7 @@ Return<RequestStatus> BiometricsFingerprint::ErrorFilter(int32_t error) {
 }
 
 Return<uint64_t> BiometricsFingerprint::setNotify(
-        const sp<IBiometricsFingerprintClientCallback>& clientCallback) {
+    const sp<IBiometricsFingerprintClientCallback> &clientCallback) {
     std::lock_guard<std::mutex> lock(mClientCallbackMutex);
     mClientCallback = clientCallback;
     // This is here because HAL 2.1 doesn't have a way to propagate a
@@ -92,29 +105,29 @@ Return<uint64_t> BiometricsFingerprint::setNotify(
     return reinterpret_cast<uint64_t>(mDevice);
 }
 
-Return<uint64_t> BiometricsFingerprint::preEnroll()  {
+Return<uint64_t> BiometricsFingerprint::preEnroll() {
     mDevice->challenge = fpc_load_auth_challenge(mDevice->fpc);
-    ALOGI("%s : Challenge is : %ju",__func__, mDevice->challenge);
+    ALOGI("%s : Challenge is : %ju", __func__, mDevice->challenge);
     return mDevice->challenge;
 }
 
-Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69>& hat,
-        uint32_t gid ATTRIBUTE_UNUSED,
-        uint32_t timeoutSec ATTRIBUTE_UNUSED) {
-    const hw_auth_token_t* authToken =
-        reinterpret_cast<const hw_auth_token_t*>(hat.data());
+Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69> &hat,
+                                                    uint32_t gid ATTRIBUTE_UNUSED,
+                                                    uint32_t timeoutSec ATTRIBUTE_UNUSED) {
+    const hw_auth_token_t *authToken =
+        reinterpret_cast<const hw_auth_token_t *>(hat.data());
 
     if (!mWt.Pause())
         return RequestStatus::SYS_EBUSY;
 
-    ALOGI("%s : hat->challenge %lu",__func__,(unsigned long) authToken->challenge);
-    ALOGI("%s : hat->user_id %lu",__func__,(unsigned long) authToken->user_id);
-    ALOGI("%s : hat->authenticator_id %lu",__func__,(unsigned long) authToken->authenticator_id);
-    ALOGI("%s : hat->authenticator_type %d",__func__,authToken->authenticator_type);
-    ALOGI("%s : hat->timestamp %lu",__func__,(unsigned long) authToken->timestamp);
-    ALOGI("%s : hat size %lu",__func__,(unsigned long) sizeof(hw_auth_token_t));
+    ALOGI("%s : hat->challenge %lu", __func__, (unsigned long)authToken->challenge);
+    ALOGI("%s : hat->user_id %lu", __func__, (unsigned long)authToken->user_id);
+    ALOGI("%s : hat->authenticator_id %lu", __func__, (unsigned long)authToken->authenticator_id);
+    ALOGI("%s : hat->authenticator_type %d", __func__, authToken->authenticator_type);
+    ALOGI("%s : hat->timestamp %lu", __func__, (unsigned long)authToken->timestamp);
+    ALOGI("%s : hat size %lu", __func__, (unsigned long)sizeof(hw_auth_token_t));
 
-    fpc_verify_auth_challenge(mDevice->fpc, (void*) authToken, sizeof(hw_auth_token_t));
+    fpc_verify_auth_challenge(mDevice->fpc, (void *)authToken, sizeof(hw_auth_token_t));
 
     bool success = mWt.waitForState(AsyncState::Enroll);
     return success ? RequestStatus::SYS_OK : RequestStatus::SYS_EAGAIN;
@@ -128,12 +141,12 @@ Return<RequestStatus> BiometricsFingerprint::postEnroll() {
 
 Return<uint64_t> BiometricsFingerprint::getAuthenticatorId() {
     uint64_t id = fpc_load_db_id(mDevice->fpc);
-    ALOGI("%s : ID : %ju",__func__,id );
+    ALOGI("%s : ID : %ju", __func__, id);
     return id;
 }
 
 Return<RequestStatus> BiometricsFingerprint::cancel() {
-    ALOGI("%s",__func__);
+    ALOGI("%s", __func__);
 
     if (mWt.Resume()) {
         ALOGI("%s : Successfully moved to pause state", __func__);
@@ -145,7 +158,6 @@ Return<RequestStatus> BiometricsFingerprint::cancel() {
 }
 
 Return<RequestStatus> BiometricsFingerprint::enumerate() {
-
     const uint64_t devId = reinterpret_cast<uint64_t>(mDevice);
     if (mClientCallback == nullptr) {
         ALOGE("Client callback not set");
@@ -169,9 +181,9 @@ Return<RequestStatus> BiometricsFingerprint::enumerate() {
         mClientCallback->onEnumerate(devId, 0, mDevice->gid, 0);
     else
         for (size_t i = 0; i < print_indexs.print_count; i++) {
-            ALOGD("%s : found print : %lu at index %zu", __func__, (unsigned long) print_indexs.prints[i], i);
+            ALOGD("%s : found print : %lu at index %zu", __func__, (unsigned long)print_indexs.prints[i], i);
 
-            uint32_t  remaining_templates = (uint32_t)(print_indexs.print_count - i - 1);
+            uint32_t remaining_templates = (uint32_t)(print_indexs.print_count - i - 1);
 
             mClientCallback->onEnumerate(devId, print_indexs.prints[i], mDevice->gid, remaining_templates);
         }
@@ -182,7 +194,6 @@ Return<RequestStatus> BiometricsFingerprint::enumerate() {
 }
 
 Return<RequestStatus> BiometricsFingerprint::remove(uint32_t gid, uint32_t fid) {
-
     const uint64_t devId = reinterpret_cast<uint64_t>(mDevice);
 
     if (mClientCallback == nullptr) {
@@ -195,12 +206,11 @@ Return<RequestStatus> BiometricsFingerprint::remove(uint32_t gid, uint32_t fid) 
 
     Return<RequestStatus> ret = RequestStatus::SYS_OK;
 
-    if (fpc_del_print_id(mDevice->fpc, fid) == 0){
-
-        mClientCallback->onRemoved(devId, fid, gid,0);
+    if (fpc_del_print_id(mDevice->fpc, fid) == 0) {
+        mClientCallback->onRemoved(devId, fid, gid, 0);
 
         uint32_t db_length = fpc_get_user_db_length(mDevice->fpc);
-        ALOGD("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
+        ALOGD("%s : User Database Length Is : %lu", __func__, (unsigned long)db_length);
         fpc_store_user_db(mDevice->fpc, db_length, mDevice->db_path);
         ret = ErrorFilter(0);
     } else {
@@ -218,7 +228,7 @@ int BiometricsFingerprint::__setActiveGroup(uint32_t gid) {
     bool created_empty_db = false;
     struct stat sb;
 
-    if(stat(mDevice->db_path, &sb) == -1) {
+    if (stat(mDevice->db_path, &sb) == -1) {
         // No existing database, load an empty one
         if ((result = fpc_load_empty_db(mDevice->fpc)) != 0) {
             ALOGE("Error creating empty user database: %d\n", result);
@@ -232,15 +242,13 @@ int BiometricsFingerprint::__setActiveGroup(uint32_t gid) {
         }
     }
 
-    if((result = fpc_set_gid(mDevice->fpc, gid)) != 0)
-    {
+    if ((result = fpc_set_gid(mDevice->fpc, gid)) != 0) {
         ALOGE("Error setting current gid: %d\n", result);
     }
 
     // if user database was created in this instance, store it directly
-    if(created_empty_db)
-    {
-        int length  = fpc_get_user_db_length(mDevice->fpc);
+    if (created_empty_db) {
+        int length = fpc_get_user_db_length(mDevice->fpc);
         fpc_store_user_db(mDevice->fpc, length, mDevice->db_path);
         if ((result = fpc_load_user_db(mDevice->fpc, mDevice->db_path)) != 0) {
             ALOGE("Error loading empty user database: %d\n", result);
@@ -251,8 +259,7 @@ int BiometricsFingerprint::__setActiveGroup(uint32_t gid) {
 }
 
 Return<RequestStatus> BiometricsFingerprint::setActiveGroup(uint32_t gid,
-        const hidl_string& storePath) {
-
+                                                            const hidl_string &storePath) {
     int result;
 
     if (storePath.size() >= PATH_MAX || storePath.size() <= 0) {
@@ -263,7 +270,7 @@ Return<RequestStatus> BiometricsFingerprint::setActiveGroup(uint32_t gid,
         return RequestStatus::SYS_EINVAL;
     }
 
-    sprintf(mDevice->db_path,"%s/user.db", storePath.c_str());
+    sprintf(mDevice->db_path, "%s/user.db", storePath.c_str());
     mDevice->gid = gid;
 
     ALOGI("%s : storage path set to : %s", __func__, mDevice->db_path);
@@ -279,8 +286,7 @@ Return<RequestStatus> BiometricsFingerprint::setActiveGroup(uint32_t gid,
 }
 
 Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operation_id,
-        uint32_t gid ATTRIBUTE_UNUSED) {
-
+                                                          uint32_t gid ATTRIBUTE_UNUSED) {
     err_t r;
 
     ALOGI("%s: operation_id=%ju", __func__, operation_id);
@@ -291,7 +297,7 @@ Return<RequestStatus> BiometricsFingerprint::authenticate(uint64_t operation_id,
     r = fpc_set_auth_challenge(mDevice->fpc, operation_id);
     auth_challenge = operation_id;
     if (r < 0) {
-        ALOGE("%s: Error setting auth challenge to %ju. r=0x%08X",__func__, operation_id, r);
+        ALOGE("%s: Error setting auth challenge to %ju. r=0x%08X", __func__, operation_id, r);
         return RequestStatus::SYS_EAGAIN;
     }
 
@@ -312,7 +318,7 @@ void BiometricsFingerprint::IdleAsync() {
     // This gives the service some time to execute multiple commands on the HAL
     // sequentially before needlessly going into navigation mode and exit it
     // almost immediately after.
-    else if(mWt.isEventAvailable(500)) {
+    else if (mWt.isEventAvailable(500)) {
         ALOGD("%s: EXIT: Handle event instead of navigation", __func__);
         return;
     }
@@ -359,16 +365,14 @@ void BiometricsFingerprint::EnrollAsync() {
     }
 
     int ret = fpc_enroll_start(mDevice->fpc, print_count);
-    if(ret < 0)
-    {
+    if (ret < 0) {
         ALOGE("Starting enroll failed: %d\n", ret);
     }
 
     int status = 1;
 
-    while((status = fpc_capture_image(mDevice->fpc)) >= 0) {
+    while ((status = fpc_capture_image(mDevice->fpc)) >= 0) {
         ALOGD("%s : Got Input status=%d", __func__, status);
-
 
         if (mWt.isEventAvailable()) {
             mClientCallback->onError(devId, FingerprintError::ERROR_CANCELED, 0);
@@ -389,27 +393,25 @@ void BiometricsFingerprint::EnrollAsync() {
             if (ret > 0) {
                 ALOGI("%s : Touches Remaining : %d", __func__, remaining_touches);
                 if (remaining_touches > 0) {
-                    mClientCallback->onEnrollResult(devId, 0, 0,remaining_touches);
+                    mClientCallback->onEnrollResult(devId, 0, 0, remaining_touches);
                 }
-            }
-            else if (ret == 0) {
+            } else if (ret == 0) {
                 uint32_t print_id = 0;
                 int print_index = fpc_enroll_end(mDevice->fpc, &print_id);
 
-                if (print_index < 0){
-                    ALOGE("%s : Error getting new print index : %d", __func__,print_index);
+                if (print_index < 0) {
+                    ALOGE("%s : Error getting new print index : %d", __func__, print_index);
                     mClientCallback->onError(devId, FingerprintError::ERROR_UNABLE_TO_PROCESS, 0);
                     break;
                 }
 
                 uint32_t db_length = fpc_get_user_db_length(mDevice->fpc);
-                ALOGI("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
+                ALOGI("%s : User Database Length Is : %lu", __func__, (unsigned long)db_length);
                 fpc_store_user_db(mDevice->fpc, db_length, mDevice->db_path);
-                ALOGI("%s : Got print id : %lu", __func__,(unsigned long) print_id);
+                ALOGI("%s : Got print id : %lu", __func__, (unsigned long)print_id);
                 mClientCallback->onEnrollResult(devId, print_id, mDevice->gid, 0);
                 break;
-            }
-            else {
+            } else {
                 ALOGE("Error in enroll step, aborting enroll: %d\n", ret);
                 mClientCallback->onError(devId, FingerprintError::ERROR_UNABLE_TO_PROCESS, 0);
                 break;
@@ -423,7 +425,6 @@ void BiometricsFingerprint::EnrollAsync() {
     if (status < 0)
         mClientCallback->onError(devId, FingerprintError::ERROR_HW_UNAVAILABLE, 0);
 }
-
 
 void BiometricsFingerprint::AuthenticateAsync() {
     int result;
@@ -445,7 +446,7 @@ void BiometricsFingerprint::AuthenticateAsync() {
 
     fpc_auth_start(mDevice->fpc);
 
-    while((status = fpc_capture_image(mDevice->fpc)) >= 0 ) {
+    while ((status = fpc_capture_image(mDevice->fpc)) >= 0) {
         ALOGV("%s : Got Input with status %d", __func__, status);
 
         if (mWt.isEventAvailable()) {
@@ -459,7 +460,6 @@ void BiometricsFingerprint::AuthenticateAsync() {
             mClientCallback->onAcquired(devId, hidlStatus, 0);
 
         if (status == FINGERPRINT_ACQUIRED_GOOD) {
-
             uint32_t print_id = 0;
             int verify_state = fpc_auth_step(mDevice->fpc, &print_id);
             ALOGI("%s : Auth step = %d", __func__, verify_state);
@@ -507,7 +507,7 @@ void BiometricsFingerprint::AuthenticateAsync() {
 
                     fid = print_id;
 
-                    const uint8_t* hat2 = reinterpret_cast<const uint8_t*>(&hat);
+                    const uint8_t *hat2 = reinterpret_cast<const uint8_t *>(&hat);
                     const hidl_vec<uint8_t> token(std::vector<uint8_t>(hat2, hat2 + sizeof(hat)));
 
                     mClientCallback->onAuthenticated(devId, fid, gid, token);

--- a/BiometricsFingerprint.h
+++ b/BiometricsFingerprint.h
@@ -17,29 +17,31 @@
 #ifndef ANDROID_HARDWARE_BIOMETRICS_FINGERPRINT_V2_1_BIOMETRICSFINGERPRINT_H
 #define ANDROID_HARDWARE_BIOMETRICS_FINGERPRINT_V2_1_BIOMETRICSFINGERPRINT_H
 
-#include <log/log.h>
+#include "SynchronizedWorkerThread.h"
+
+#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
 #include <hardware/fingerprint.h>
 #include <hidl/MQDescriptor.h>
 #include <hidl/Status.h>
-#include <android/hardware/biometrics/fingerprint/2.1/IBiometricsFingerprint.h>
+#include <log/log.h>
+
 #include <mutex>
-#include "SynchronizedWorkerThread.h"
 
 extern "C" {
-    #include "fpc_imp.h"
+#include "fpc_imp.h"
 }
 
 namespace fpc {
 
+using ::android::sp;
+using ::android::hardware::hidl_array;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint;
 using ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprintClientCallback;
 using ::android::hardware::biometrics::fingerprint::V2_1::RequestStatus;
-using ::android::hardware::Return;
-using ::android::hardware::Void;
-using ::android::hardware::hidl_array;
-using ::android::hardware::hidl_vec;
-using ::android::hardware::hidl_string;
-using ::android::sp;
 
 typedef struct {
     fpc_imp_data_t *fpc;
@@ -54,19 +56,19 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public ::Synchroni
     ~BiometricsFingerprint();
 
     // Methods from ::android::hardware::biometrics::fingerprint::V2_1::IBiometricsFingerprint follow.
-    Return<uint64_t> setNotify(const sp<IBiometricsFingerprintClientCallback>& clientCallback) override;
+    Return<uint64_t> setNotify(const sp<IBiometricsFingerprintClientCallback> &clientCallback) override;
     Return<uint64_t> preEnroll() override;
-    Return<RequestStatus> enroll(const hidl_array<uint8_t, 69>& hat, uint32_t gid, uint32_t timeoutSec) override;
+    Return<RequestStatus> enroll(const hidl_array<uint8_t, 69> &hat, uint32_t gid, uint32_t timeoutSec) override;
     Return<RequestStatus> postEnroll() override;
     Return<uint64_t> getAuthenticatorId() override;
     Return<RequestStatus> cancel() override;
     Return<RequestStatus> enumerate() override;
     Return<RequestStatus> remove(uint32_t gid, uint32_t fid) override;
-    Return<RequestStatus> setActiveGroup(uint32_t gid, const hidl_string& storePath) override;
+    Return<RequestStatus> setActiveGroup(uint32_t gid, const hidl_string &storePath) override;
     Return<RequestStatus> authenticate(uint64_t operationId, uint32_t gid) override;
 
     // Methods from ::SynchronizedWorker::WorkHandler
-    inline ::SynchronizedWorker::Thread& getWorker() override {
+    inline ::SynchronizedWorker::Thread &getWorker() override {
         return mWt;
     }
     void AuthenticateAsync() override;
@@ -82,7 +84,7 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public ::Synchroni
     ::SynchronizedWorker::Thread mWt;
     std::mutex mClientCallbackMutex;
     sp<IBiometricsFingerprintClientCallback> mClientCallback;
-    sony_fingerprint_device_t* mDevice;
+    sony_fingerprint_device_t *mDevice;
     uint64_t auth_challenge;
 };
 

--- a/UInput.cpp
+++ b/UInput.cpp
@@ -116,7 +116,10 @@ static int fpc_write_input_event(const fpc_uinput_t *uinput, unsigned short type
     };
 
     int written = write(uinput->fd, &ie, sizeof(ie));
-    if (written != sizeof(ie)) {
+    if (written < 0) {
+        ALOGE("Failed to write legacy uinput setup! rc=%d: %s", written, strerror(errno));
+        return -1;
+    } else if (written != sizeof(ie)) {
         ALOGE("Didn't write full input_event, only %d/%zu bytes!", written, sizeof(ie));
         return -1;
     }


### PR DESCRIPTION
This PR implements the missing loop to delete all fingerprints when a ::delete() call is made with fid=0. Android doesn't seem to call this (anymore?) yet we do have the loop in Egistec and I most definitely remember seeing it in action there. Since this is part of the spec and used by other OSes like Sailfish, implement it.

Also includes more cleanups, such as the much-needed autoformat to get these source files in a consistent state (all fpc_ files will follow when I have to touch them again). Browsing unformatted inconsistent code is a borderline okay; having to carefully reformat only edited sections is a waste of time. One hotkey to rule it all!

Thanks @rinigus for reporting this issue! May I ask you to return the favour and validate + review this pull request, pretty please? :grin:
