### PR TITLE
[2/3] [FINGERPRINT] Clean up macros and configure Seine

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -49,6 +49,7 @@ endif
 
 ifeq ($(filter-out kumano seine,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += \
+    -DEGISTEC_SAVE_TEMPLATE_RETURNS_SIZE \
     -DEGIS_QSEE_APP_NAME=\"egista\" \
     -DEGIS_QSEE_APP_PATH=\"/odm/firmware\"
 else

--- a/Android.mk
+++ b/Android.mk
@@ -43,11 +43,11 @@ LOCAL_CFLAGS += \
 endif
 
 # ---------------- Egistec ----------------
-ifeq ($(filter-out nile ganges kumano,$(SOMC_PLATFORM)),)
+ifeq ($(filter-out nile ganges kumano seine,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += -DFINGERPRINT_TYPE_EGISTEC
 endif
 
-ifeq ($(filter-out kumano,$(SOMC_PLATFORM)),)
+ifeq ($(filter-out kumano seine,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += \
     -DEGIS_QSEE_APP_NAME=\"egista\" \
     -DEGIS_QSEE_APP_PATH=\"/odm/firmware\"
@@ -57,7 +57,7 @@ LOCAL_CFLAGS += \
 endif
 
 # Define dynamic power management for everything but the following platforms:
-ifneq ($(filter-out kumano,$(SOMC_PLATFORM)),)
+ifneq ($(filter-out kumano seine,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 

--- a/Android.mk
+++ b/Android.mk
@@ -13,44 +13,52 @@ LOCAL_SRC_FILES := \
     ion_buffer.c \
     common.c
 
+# ---------------- FPC ----------------
 ifeq ($(filter-out loire tone,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_loire_tone.c
 HAS_FPC := true
-LOCAL_CFLAGS += -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifeq ($(filter-out yoshino,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
 LOCAL_CFLAGS += \
-    -DUSE_FPC_YOSHINO \
-    -DHAS_DYNAMIC_POWER_MANAGEMENT
+    -DUSE_FPC_YOSHINO
 endif
 
 ifeq ($(filter-out nile,$(SOMC_PLATFORM)),)
+# NOTE: Nile can have either FPC or Egistec
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
 LOCAL_CFLAGS += \
     -DUSE_FPC_NILE \
-    -DHAS_DYNAMIC_POWER_MANAGEMENT
+    -DHAS_LEGACY_EGISTEC
 endif
 
 ifeq ($(filter-out tama,$(SOMC_PLATFORM)),)
 LOCAL_SRC_FILES += fpc_imp_yoshino_nile_tama.c
 HAS_FPC := true
 LOCAL_CFLAGS += \
-    -DUSE_FPC_TAMA \
-    -DHAS_DYNAMIC_POWER_MANAGEMENT
+    -DUSE_FPC_TAMA
 endif
 
-ifeq ($(filter-out ganges,$(SOMC_PLATFORM)),)
-LOCAL_CFLAGS += \
-    -DUSE_FPC_GANGES \
-    -DHAS_DYNAMIC_POWER_MANAGEMENT
+# ---------------- Egistec ----------------
+ifeq ($(filter-out nile ganges kumano,$(SOMC_PLATFORM)),)
+LOCAL_CFLAGS += -DFINGERPRINT_TYPE_EGISTEC
 endif
 
 ifeq ($(filter-out kumano,$(SOMC_PLATFORM)),)
-LOCAL_CFLAGS += -DUSE_FPC_KUMANO
+LOCAL_CFLAGS += \
+    -DEGIS_QSEE_APP_NAME=\"egista\" \
+    -DEGIS_QSEE_APP_PATH=\"/odm/firmware\"
+else
+LOCAL_CFLAGS += \
+    -DEGIS_QSEE_APP_NAME=\"egisap32\"
+endif
+
+# Define dynamic power management for everything but the following platforms:
+ifneq ($(filter-out kumano,$(SOMC_PLATFORM)),)
+LOCAL_CFLAGS += -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 
 ifneq ($(HAS_FPC),true)

--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -266,8 +266,11 @@ int BiometricsFingerprint::__setActiveGroup(uint32_t gid) {
     // if user database was created in this instance, store it directly
     if (created_empty_db) {
         int length = fpc_get_user_db_length(mDevice->fpc);
-        fpc_store_user_db(mDevice->fpc, length, mDevice->db_path);
-        if ((result = fpc_load_user_db(mDevice->fpc, mDevice->db_path)) != 0) {
+        if ((result = fpc_store_user_db(mDevice->fpc, length, mDevice->db_path))) {
+            ALOGE("Failed to store empty user database: %d\n", result);
+            return result;
+        }
+        if ((result = fpc_load_user_db(mDevice->fpc, mDevice->db_path))) {
             ALOGE("Error loading empty user database: %d\n", result);
             return result;
         }

--- a/egistec/EgisFpDevice.cpp
+++ b/egistec/EgisFpDevice.cpp
@@ -66,7 +66,7 @@ int EgisFpDevice::GetFd() const {
     return mFd;
 }
 
-#ifdef USE_FPC_NILE
+#ifdef HAS_LEGACY_EGISTEC
 FpHwId EgisFpDevice::GetHwId() const {
     FpHwId id;
     int rc = ioctl(mFd, ET51X_IOCRHWTYPE, &id);

--- a/egistec/EgisFpDevice.h
+++ b/egistec/EgisFpDevice.h
@@ -50,7 +50,7 @@ class EgisFpDevice {
 
     // TODO: Move/abstract this if we ever get more
     // platforms with multiple sensor types.
-#ifdef USE_FPC_NILE
+#ifdef HAS_LEGACY_EGISTEC
     /**
      * Retrieve hardware ID from the FPC driver.
      * Currently only has a meaning on the Nile platform,

--- a/egistec/current/BiometricsFingerprint.cpp
+++ b/egistec/current/BiometricsFingerprint.cpp
@@ -496,7 +496,7 @@ void BiometricsFingerprint::IdleAsync() {
     int rc = 0;
     int which;
 
-    if (mHwId >= 0x600) {
+    if (mHwId >= 0x600 || mHwId == 0x37) {
         // 6xx does not support gestures.
         rc = mTrustlet.SetWorkMode(WorkMode::Sleep);
         LOG_ALWAYS_FATAL_IF(rc, "SetWorkMode(WorkMode::Sleep) failed with rc=%d", rc);

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -441,7 +441,17 @@ int EGISAPTrustlet::InitializeIdentify() {
 }
 
 int EGISAPTrustlet::SaveTemplate() {
+#ifdef EGISTEC_SAVE_TEMPLATE_RETURNS_SIZE
+    TypedIonBuffer<uint32_t> result;
+    int rc = CAPTURE_ERROR(SendModifiedCommand(result, CommandId::SaveTemplate));
+    if (rc)
+        return rc;
+
+    ALOGD("Template save size = %d", *result);
+    return 0;
+#else
     return CAPTURE_ERROR(SendCommand(CommandId::SaveTemplate));
+#endif
 }
 
 int EGISAPTrustlet::UpdateTemplate(bool &updated) {

--- a/egistec/current/EGISAPTrustlet.cpp
+++ b/egistec/current/EGISAPTrustlet.cpp
@@ -49,11 +49,12 @@ void log_hex(const char *data, int length) {
     free(base);
 }
 
-#ifdef USE_FPC_KUMANO
-EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet("egista", 0x2400, /* path: */ "/odm/firmware") {
-#else
-EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet("egisap32", 0x2400) {
+EGISAPTrustlet::EGISAPTrustlet() : QSEETrustlet(EGIS_QSEE_APP_NAME, 0x2400
+#ifdef EGIS_QSEE_APP_PATH
+                                                ,
+                                                EGIS_QSEE_APP_PATH
 #endif
+                                   ) {
 }
 
 int EGISAPTrustlet::SendCommand(EGISAPTrustlet::API &api) {

--- a/service.cpp
+++ b/service.cpp
@@ -37,11 +37,11 @@ using CurrentEgistecHAL = ::egistec::current::BiometricsFingerprint;
 int main() {
     android::sp<IBiometricsFingerprint> bio;
 
-#if defined(USE_FPC_NILE) || defined(USE_FPC_GANGES) || defined(USE_FPC_KUMANO)
+#if defined(FINGERPRINT_TYPE_EGISTEC)
     ::egistec::EgisFpDevice dev;
 #endif
 
-#ifdef USE_FPC_NILE
+#if defined(HAS_LEGACY_EGISTEC)
     auto type = dev.GetHwId();
     bool is_old_hal;
 
@@ -72,7 +72,7 @@ int main() {
             ALOGE("No HAL instance defined for hardware type %d", type);
             return 1;
     }
-#elif defined(USE_FPC_GANGES) || defined(USE_FPC_KUMANO)
+#elif defined(FINGERPRINT_TYPE_EGISTEC)
     bio = new CurrentEgistecHAL(std::move(dev));
 #else
     bio = new FPCHAL();


### PR DESCRIPTION
Needs https://github.com/sonyxperiadev/kernel/pull/2319

Some small cleanups to make configuration more obvious, by defining traits in the makefile instead of `#ifdef`ing on platforms in the code. The Seine sensor is pretty much identical to Kumano: runtime power management == wholly unstable, and gestures are inexistant.

### DO NOT MERGE! TODO:
- [x] Test updated `Android.mk` on other platforms (Nile, Ganges, Kumano); I may have made a typo...
- [x] Find and fix error in `SaveTemplate`;
- [ ] Check up on the hwid.
