### PR TITLE
[fingerprint] [Q/R] FPC: Remove unused (always zero) database length (Kitakami leftover)

### DIFF
--- a/BiometricsFingerprint.cpp
+++ b/BiometricsFingerprint.cpp
@@ -224,9 +224,7 @@ Return<RequestStatus> BiometricsFingerprint::remove(uint32_t gid, uint32_t fid) 
     if (rc) {
         mClientCallback->onError(devId, FingerprintError::ERROR_UNABLE_TO_REMOVE, 0);
     } else {
-        uint32_t db_length = fpc_get_user_db_length(fpc);
-        ALOGD("%s : User Database Length Is : %u", __func__, db_length);
-        rc = fpc_store_user_db(fpc, db_length, db_path);
+        rc = fpc_store_user_db(fpc, db_path);
     }
 
     mWt.Resume();
@@ -259,8 +257,7 @@ int BiometricsFingerprint::__setActiveGroup(uint32_t gid) {
 
     // if user database was created in this instance, store it directly
     if (created_empty_db) {
-        int length = fpc_get_user_db_length(fpc);
-        if ((result = fpc_store_user_db(fpc, length, db_path))) {
+        if ((result = fpc_store_user_db(fpc, db_path))) {
             ALOGE("Failed to store empty user database: %d\n", result);
             return result;
         }
@@ -419,9 +416,7 @@ void BiometricsFingerprint::EnrollAsync() {
                     break;
                 }
 
-                uint32_t db_length = fpc_get_user_db_length(fpc);
-                ALOGI("%s : User Database Length Is : %lu", __func__, (unsigned long)db_length);
-                fpc_store_user_db(fpc, db_length, db_path);
+                fpc_store_user_db(fpc, db_path);
                 ALOGI("%s : Got print id : %lu", __func__, (unsigned long)print_id);
                 mClientCallback->onEnrollResult(devId, print_id, gid, 0);
                 break;
@@ -490,7 +485,7 @@ void BiometricsFingerprint::AuthenticateAsync() {
                     ALOGE("Error updating template: %d", result);
                 } else if (result) {
                     ALOGI("Storing db");
-                    result = fpc_store_user_db(fpc, 0, db_path);
+                    result = fpc_store_user_db(fpc, db_path);
                     if (result) ALOGE("Error storing database: %d", result);
                 }
 

--- a/fpc_imp.h
+++ b/fpc_imp.h
@@ -56,13 +56,10 @@ err_t fpc_auth_start(fpc_imp_data_t *data); //start auth
 err_t fpc_auth_step(fpc_imp_data_t *data, uint32_t *print_id); //step forward auth & process image (only available if capture image returns OK)
 err_t fpc_auth_end(fpc_imp_data_t *data); //end auth
 err_t fpc_update_template(fpc_imp_data_t *data); // Update fingerprint template
-// FIXME: This should be internal to kitakami implementation
-err_t fpc_get_user_db_length(fpc_imp_data_t *data); //get size of working db
 err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid);
 err_t fpc_load_user_db(fpc_imp_data_t *data, char* path); //load user DB into TZ app from storage
 err_t fpc_load_empty_db(fpc_imp_data_t *data);
-// FIXME: length should be fetched internally in kitakami implementation
-err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t length, char* path); //store running TZ db
+err_t fpc_store_user_db(fpc_imp_data_t *data, char* path); //store running TZ db
 err_t fpc_close(fpc_imp_data_t **data); //close this implementation
 err_t fpc_init(fpc_imp_data_t **data, int event_fd); //init sensor
 

--- a/fpc_imp_loire_tone.c
+++ b/fpc_imp_loire_tone.c
@@ -554,13 +554,6 @@ err_t fpc_get_print_index(fpc_imp_data_t *data, fpc_fingerprint_index_t *idx_dat
     return 0;
 }
 
-
-err_t fpc_get_user_db_length(fpc_imp_data_t __unused *data)
-{
-    ALOGV(__func__);
-    return 0;
-}
-
 err_t fpc_load_empty_db(fpc_imp_data_t *data) {
     err_t result;
     fpc_data_t *ldata = (fpc_data_t*)data;
@@ -603,7 +596,7 @@ err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid)
     return result;
 }
 
-err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t __unused length, char* path)
+err_t fpc_store_user_db(fpc_imp_data_t *data, char* path)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;

--- a/fpc_imp_yoshino_nile_tama.c
+++ b/fpc_imp_yoshino_nile_tama.c
@@ -721,13 +721,6 @@ err_t fpc_get_print_index(fpc_imp_data_t *data, fpc_fingerprint_index_t *idx_dat
     return 0;
 }
 
-
-err_t fpc_get_user_db_length(fpc_imp_data_t __unused *data)
-{
-    ALOGV(__func__);
-    return 0;
-}
-
 err_t fpc_load_empty_db(fpc_imp_data_t *data) {
     err_t result;
     fpc_data_t *ldata = (fpc_data_t*)data;
@@ -770,7 +763,7 @@ err_t fpc_set_gid(fpc_imp_data_t *data, uint32_t gid)
     return result;
 }
 
-err_t fpc_store_user_db(fpc_imp_data_t *data, uint32_t __unused length, char* path)
+err_t fpc_store_user_db(fpc_imp_data_t *data, char* path)
 {
     ALOGV(__func__);
     fpc_data_t *ldata = (fpc_data_t*)data;


### PR DESCRIPTION
Depends on #71

This is apparently internal to Kitakami, that's not supported by this HAL at all for _years_. In the event that one ever wishes to do so, it should be retrieved internally in `fpc_store_user_db` as the `FIXME` comment explains.

Remove the call now, as it only leads to unnecessary confusion while reading the logs and code.

Tested on:
- [x] Akatsuki Android 10:
  - [x] Gestures
  - [x] Authentication
  - [x] Fingerprint removal
  - [x] Enrolling
- [ ] Some Loire/Tone device:
  - [ ] A build-test would be enough.