### PR TITLE
Update Lena app name to `egisap`, residing on `firmware_mnt/`

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -52,6 +52,10 @@ LOCAL_CFLAGS += \
     -DEGISTEC_SAVE_TEMPLATE_RETURNS_SIZE \
     -DEGIS_QSEE_APP_NAME=\"egista\" \
     -DEGIS_QSEE_APP_PATH=\"/odm/firmware\"
+else ifeq ($(filter-out lena,$(SOMC_PLATFORM)),)
+LOCAL_CFLAGS += \
+    -DEGISTEC_SAVE_TEMPLATE_RETURNS_SIZE \
+    -DEGIS_QSEE_APP_NAME=\"egista\"
 else
 LOCAL_CFLAGS += \
     -DEGIS_QSEE_APP_NAME=\"egisap32\"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,19 @@ It makes use of the TrustZone (TZ) fingerprint application via the QSEECOM API (
 
 * This was based around the OnePlus Two TrustZone fingerprint HAL (found here https://github.com/CyanogenMod/android_device_oneplus_oneplus2/blob/cm-13.0/fingerprint)
 * Extra information was obtained from the Nexus 6P (angler kernel driver) (found here https://android.googlesource.com/kernel/msm/+/3d0a564505ab8452e7e6f52b972db386cc2f5f69)
-* Protocol informations was verified as it passed through the QSEECOM API to linux kernel
+* Protocol information was verified as it passed through the QSEECOM API to linux kernel
 
+## Rebuild and run quickly
+
+```console
+$ m android.hardware.biometrics.fingerprint@2.1-service.sony && adb sync && adb shell setprop ctl.restart fps_hal
+```
+
+On devices where `adb sync` tries to sync too much, in turn running out of inodes, push the binary directly. For PDX213 for example:
+
+```console
+$ m android.hardware.biometrics.fingerprint@2.1-service.sony && adb push out/target/product/pdx213/vendor/bin/hw/android.hardware.biometrics.fingerprint@2.1-service.sony vendor/bin/hw && adb shell setprop ctl.restart fps_hal
+```
 
 ## License ##
 


### PR DESCRIPTION
Lena's fingerprint sensor has also been tested to operate properly when dynamic power management is enabled.  Especially without support for (always-on!) fingerprint gestures this saves minimal power when the sensor is not actively waiting for a finger (ie. the phone is unlocked).

