### PR TITLE
android: Allow dynamic power management on Edo

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -58,7 +58,7 @@ LOCAL_CFLAGS += \
 endif
 
 # Define dynamic power management for everything but the following platforms:
-ifneq ($(filter-out kumano seine edo,$(SOMC_PLATFORM)),)
+ifneq ($(filter-out kumano seine,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += -DHAS_DYNAMIC_POWER_MANAGEMENT
 endif
 


### PR DESCRIPTION
Edo devices seem to have no trouble with dynamically cutting power to the fingerprint sensor when it's not used, which is especially relevant considering the lack of gesture navigation.  Without this feature the sensor can be fully turned off while the user is operating the device (ie. it's unlocked).
Actual drain is probably negligible but it's reasonable to represent what the hardware supports nevertheless.  It appears Edo was excluded from this feature during enablement for no good reason other than Kumano and Seine also being in this list.

Fixes: 74f4599 ("Android.mk: enable fingerprint for edo devices")
