### PR TITLE
Android.mk: Add Nile to platforms with Egistec

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -43,7 +43,7 @@ LOCAL_CFLAGS += \
 endif
 
 # ---------------- Egistec ----------------
-ifneq ($(filter-out loire tone yoshino nile tama,$(SOMC_PLATFORM)),)
+ifneq ($(filter-out loire tone yoshino tama,$(SOMC_PLATFORM)),)
 LOCAL_CFLAGS += -DFINGERPRINT_TYPE_EGISTEC
 endif
 


### PR DESCRIPTION
In previous commit ifeq was changed to ifneq and devices
that do not have egistec fp were added into this list.

Nile has Egistec and also can have different fpc.

Thus remove it from the list of platforms that do not have Egistec.

Fixes: 694d5f6e2655a8dfbccb909897d27f5369229274

Signed-off-by: Martin Botka <martin.botka@somainline.org>