### PR TITLE
[master] Android.mk: Add LOCAL_VINTF_FRAGMENTS

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -5,6 +5,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.biometrics.fingerprint@2.1-service.sony
 LOCAL_INIT_RC := android.hardware.biometrics.fingerprint@2.1-service.sony.rc
+LOCAL_VINTF_FRAGMENTS := android.hardware.biometrics.fingerprint.xml
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_SRC_FILES := \

--- a/android.hardware.biometrics.fingerprint.xml
+++ b/android.hardware.biometrics.fingerprint.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.biometrics.fingerprint</name>
+        <transport>hwbinder</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IBiometricsFingerprint</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
Move the FPC HAL to its own project VINTF fragment. This
will allow us to avoid duplicating code and, for example,
exclude the FPC module from the build using a single flag.